### PR TITLE
Support Java 9 in OutputJVMOptions

### DIFF
--- a/xap-core/xap-datagrid/src/main/java/com/gigaspaces/internal/utils/OutputJVMOptions.java
+++ b/xap-core/xap-datagrid/src/main/java/com/gigaspaces/internal/utils/OutputJVMOptions.java
@@ -68,7 +68,9 @@ public class OutputJVMOptions {
 
     private static int getVmVersion() {
         final String vmVersion = System.getProperty("java.version");
-        final String version = vmVersion.substring(vmVersion.indexOf('.') + 1, vmVersion.lastIndexOf('.'));
+        final String version = vmVersion.contains(".")
+                ? vmVersion.substring(vmVersion.indexOf('.') + 1, vmVersion.lastIndexOf('.'))
+                : vmVersion;
         return Integer.parseInt(version);
     }
 }


### PR DESCRIPTION
Running `gs-ui.bat` on Oracle JDK 9 gives the following error:

```
java.lang.StringIndexOutOfBoundsException: begin 0, end -1, length 1
        at java.base/java.lang.String.checkBoundsBeginEnd(String.java:3116)
        at java.base/java.lang.String.substring(String.java:1885)
        at com.gigaspaces.internal.utils.OutputJVMOptions.getVmVersion(OutputJVMOptions.java:71)
        at com.gigaspaces.internal.utils.OutputJVMOptions.getJvmOptions(OutputJVMOptions.java:44)
        at com.gigaspaces.internal.utils.OutputJVMOptions.main(OutputJVMOptions.java:30)
```

This PR fixes the detection of JVM versions to support both the old JVM naming scheme (`1.8`)  and the new scheme (`9`).