### PR TITLE
GS-13897 - add support for default values in BeanLevelPropertyPlaceholderConfigurer

### DIFF
--- a/xap-core/xap-openspaces/src/main/java/org/openspaces/core/properties/BeanLevelPropertyPlaceholderConfigurer.java
+++ b/xap-core/xap-openspaces/src/main/java/org/openspaces/core/properties/BeanLevelPropertyPlaceholderConfigurer.java
@@ -31,7 +31,6 @@ import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.config.PropertyPlaceholderConfigurer;
 import org.springframework.util.PropertyPlaceholderHelper;
 
-import java.util.HashSet;
 import java.util.Properties;
 
 /**
@@ -111,8 +110,8 @@ public class BeanLevelPropertyPlaceholderConfigurer extends PropertyPlaceholderC
     }
 
     /**
-     * BeanDefinitionVisitor that resolves placeholders in String values, delegating to the
-     * <code>parseStringValue</code> method of the containing class.
+     * BeanDefinitionVisitor that resolves placeholders in String values, delegating to an instance of
+     * {@link PropertyPlaceholderHelper}.
      */
     private class PlaceholderResolvingBeanDefinitionVisitor extends BeanDefinitionVisitor {
 
@@ -121,7 +120,8 @@ public class BeanLevelPropertyPlaceholderConfigurer extends PropertyPlaceholderC
 
         public PlaceholderResolvingBeanDefinitionVisitor(Properties props) {
             this.props = props;
-            this.propertyPlaceholderHelper = new PropertyPlaceholderHelper("${", "}");
+            this.propertyPlaceholderHelper = new PropertyPlaceholderHelper(DEFAULT_PLACEHOLDER_PREFIX,
+                    DEFAULT_PLACEHOLDER_SUFFIX, DEFAULT_VALUE_SEPARATOR, true);
         }
 
         protected String resolveStringValue(String strVal) throws BeansException {


### PR DESCRIPTION
… to behave exactly like parseStringValue() in Spring 4.x.

See https://insightedge.atlassian.net/browse/GS-13897