### PR TITLE
GS-13952 Improved lib/required handling

### DIFF
--- a/xap-core/xap-common/src/main/java/com/gigaspaces/internal/io/FileUtils.java
+++ b/xap-core/xap-common/src/main/java/com/gigaspaces/internal/io/FileUtils.java
@@ -18,10 +18,14 @@ package com.gigaspaces.internal.io;
 
 import java.io.File;
 import java.io.FileFilter;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * @author Niv Ingberg
@@ -53,13 +57,27 @@ public class FileUtils {
         return fileOrDirectory.delete();
     }
 
-    public static void copyFile(File sourceFile, File destFile) throws IOException {
-        try (FileInputStream fileInputStream = new FileInputStream(sourceFile);
-             FileChannel sourceChannel = fileInputStream.getChannel();
-             FileOutputStream fileOutputStream = new FileOutputStream(destFile);
-             FileChannel destChannel = fileOutputStream.getChannel()) {
+    public static Collection<Path> list(Path p) throws IOException {
+        try (Stream<Path> stream = Files.list(p)) {
+            return stream.collect(Collectors.toList());
+        }
+    }
 
-            destChannel.transferFrom(sourceChannel, 0, sourceChannel.size());
+    public static Collection<Path> list(Path p, Predicate<Path> filter) throws IOException {
+        try (Stream<Path> stream = Files.list(p)) {
+            return stream.filter(filter).collect(Collectors.toList());
+        }
+    }
+
+    public static void forEach(Path p, Consumer<Path> consumer) throws IOException {
+        try (Stream<Path> stream = Files.list(p)) {
+            stream.forEach(consumer);
+        }
+    }
+
+    public static void forEach(Path p, Predicate<Path> filter, Consumer<Path> consumer) throws IOException {
+        try (Stream<Path> stream = Files.list(p)) {
+            stream.filter(filter).forEach(consumer);
         }
     }
 }

--- a/xap-core/xap-common/src/main/java/com/gigaspaces/internal/services/RestServiceFactory.java
+++ b/xap-core/xap-common/src/main/java/com/gigaspaces/internal/services/RestServiceFactory.java
@@ -15,10 +15,7 @@
  */
 package com.gigaspaces.internal.services;
 
-import com.gigaspaces.start.ClasspathBuilder;
-import com.gigaspaces.start.SystemInfo;
-import com.gigaspaces.start.SystemLocations;
-import com.gigaspaces.start.XapModules;
+import com.gigaspaces.start.*;
 
 /**
  * @author Niv Ingberg
@@ -37,17 +34,17 @@ public class RestServiceFactory extends ServiceFactory {
 
     @Override
     protected void initializeClasspath(ClasspathBuilder classpath) {
-        classpath.append(XapModules.ADMIN)
-                .append(XapModules.SERVICE_GRID)
-                .append(SystemLocations.singleton().libOptionalSecurity(), null, false)
-                .appendPlatform("scala")
-                // Required jars: spring-context-*, spring-beans-*, spring-core-*, spring-jcl-*, xap-datagrid, xap-asm, xap-trove
-                .appendRequired(ClasspathBuilder.startsWithFilter("slf4j-", "spring-", "xap-datagrid", "xap-openspaces", "xap-asm", "xap-trove", "xap-premium-common"))
-                .appendOptional("jetty")
-                .appendOptional("jetty/xap-jetty")
-                .appendOptional("jackson")
-                .appendOptional("metrics")
-                .appendOptional("jdbc");
+        classpath.appendJar(XapModules.ADMIN)
+                .appendJar(XapModules.SERVICE_GRID)
+                .appendAny(SystemLocations.singleton().libOptionalSecurity())
+                .appendPlatformJars("scala")
+                .appendLibRequiredJars(ClassLoaderType.COMMON)
+                .appendLibRequiredJars(ClassLoaderType.SERVICE)
+                .appendOptionalJars("jetty")
+                .appendOptionalJars("jetty/xap-jetty")
+                .appendOptionalJars("jackson")
+                .appendOptionalJars("metrics")
+                .appendOptionalJars("jdbc");
 
     }
 }

--- a/xap-core/xap-common/src/main/java/com/gigaspaces/internal/services/WebuiServiceFactory.java
+++ b/xap-core/xap-common/src/main/java/com/gigaspaces/internal/services/WebuiServiceFactory.java
@@ -1,7 +1,7 @@
 package com.gigaspaces.internal.services;
 
+import com.gigaspaces.start.ClassLoaderType;
 import com.gigaspaces.start.ClasspathBuilder;
-import com.gigaspaces.start.SystemInfo;
 import com.gigaspaces.start.SystemLocations;
 
 public class WebuiServiceFactory extends ServiceFactory {
@@ -17,16 +17,18 @@ public class WebuiServiceFactory extends ServiceFactory {
 
     @Override
     protected void initializeClasspath(ClasspathBuilder classpath) {
+        SystemLocations locations = SystemLocations.singleton();
         classpath
                 // $GS_JARS
-                .appendRequired(ClasspathBuilder.startsWithFilter("xap-", "spring-", "commons-"))
-                .append(SystemLocations.singleton().libPlatformExt())
-                .appendOptional("spring").appendOptional("security")        // $SPRING_JARS
-                .appendOptional("jetty").appendOptional("jetty/xap-jetty")
-                .appendOptional("interop")
-                .appendOptional("memoryxtend/off-heap")
-                .appendOptional("memoryxtend/rocksdb")
-                .appendPlatform("commons")
-                .appendPlatform("service-grid");
+                .appendLibRequiredJars(ClassLoaderType.COMMON)
+                .appendLibRequiredJars(ClassLoaderType.SERVICE)
+                .appendJars(locations.libPlatformExt())
+                .appendOptionalJars("spring").appendJars(locations.libOptionalSecurity())        // $SPRING_JARS
+                .appendOptionalJars("jetty").appendOptionalJars("jetty/xap-jetty")
+                .appendOptionalJars("interop")
+                .appendOptionalJars("memoryxtend/off-heap")
+                .appendOptionalJars("memoryxtend/rocksdb")
+                .appendPlatformJars("commons")
+                .appendPlatformJars("service-grid");
     }
 }

--- a/xap-core/xap-common/src/main/java/com/gigaspaces/internal/services/ZooKeeperServiceFactory.java
+++ b/xap-core/xap-common/src/main/java/com/gigaspaces/internal/services/ZooKeeperServiceFactory.java
@@ -1,5 +1,6 @@
 package com.gigaspaces.internal.services;
 
+import com.gigaspaces.start.ClassLoaderType;
 import com.gigaspaces.start.ClasspathBuilder;
 
 /**
@@ -19,10 +20,10 @@ public class ZooKeeperServiceFactory extends ServiceFactory {
 
     @Override
     protected void initializeClasspath(ClasspathBuilder classpath) {
-        classpath.appendPlatform("zookeeper")
-                .appendPlatform("service-grid")
-                // Required jars: spring-context-*, spring-beans-*, spring-core-*, spring-jcl-*, xap-datagrid, xap-asm, xap-trove
-                .appendRequired(ClasspathBuilder.startsWithFilter("slf4j-", "spring-", "xap-datagrid", "xap-openspaces", "xap-asm", "xap-trove"));
+        classpath.appendPlatformJars("zookeeper")
+                .appendPlatformJars("service-grid")
+                .appendLibRequiredJars(ClassLoaderType.COMMON)
+                .appendLibRequiredJars(ClassLoaderType.SERVICE);
 
     }
 }

--- a/xap-core/xap-common/src/main/java/com/gigaspaces/start/ClasspathBuilder.java
+++ b/xap-core/xap-common/src/main/java/com/gigaspaces/start/ClasspathBuilder.java
@@ -16,18 +16,17 @@
 
 package com.gigaspaces.start;
 
-import com.gigaspaces.internal.io.BootIOUtils;
+import com.gigaspaces.internal.io.FileUtils;
 
 import java.io.File;
-import java.io.FileFilter;
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
-import java.util.StringJoiner;
+import java.util.function.Predicate;
 
 /**
  * @author Niv Ingberg
@@ -35,110 +34,76 @@ import java.util.StringJoiner;
 @com.gigaspaces.api.InternalApi
 public class ClasspathBuilder {
 
-    private final List<File> files = new ArrayList<File>();
+    private static final SystemLocations locations = SystemLocations.singleton();
+    private static final Predicate<Path> jarsFilter = p -> p.getFileName().toString().toLowerCase().endsWith(".jar");
 
-    public ClasspathBuilder appendRequired() {
-        return appendRequired(null);
+    private final List<Path> files = new ArrayList<>();
+
+    public ClasspathBuilder appendAny(Path path) {
+        return append(path, p -> true);
     }
 
-    public ClasspathBuilder appendRequired(FileFilter filter) {
-        return append(SystemLocations.singleton().libRequired(), filter);
+    public ClasspathBuilder appendJars(Path path) {
+        return append(path, jarsFilter);
     }
 
-    public ClasspathBuilder appendPlatform(String path, String ... more) {
-        return append(SystemLocations.singleton().libPlatform().resolve(Paths.get(path, more)));
+    public ClasspathBuilder appendJars(Path path, Predicate<Path> filter) {
+        return append(path, jarsFilter.and(filter));
     }
 
-    public ClasspathBuilder appendOptional(String path) {
-        return appendOptional(path, null);
+    public ClasspathBuilder appendJar(XapModules module) {
+        return appendJars(locations.lib(module));
     }
 
-    public ClasspathBuilder appendOptional(String path, FileFilter filter) {
-        return append(SystemLocations.singleton().libOptional(path), filter);
+    public ClasspathBuilder appendLibRequiredJars(ClassLoaderType clType) {
+        for (Path path : locations.libRequired(clType))
+            appendJars(path);
+        return this;
     }
 
-    public ClasspathBuilder append(XapModules module) {
-        return append(SystemLocations.singleton().lib(module));
+    public ClasspathBuilder appendPlatformJars(String subpath) {
+        return appendJars(locations.libPlatform(subpath));
     }
 
-    public ClasspathBuilder append(Path path) {
-        return append(path, null);
+    public ClasspathBuilder appendOptionalJars(String subpath) {
+        return appendJars(locations.libOptional(subpath));
     }
 
-    public ClasspathBuilder append(Path path, FileFilter filter) {
-        return append(path, filter, true);
-    }
-
-    public ClasspathBuilder append(Path path, FileFilter filter, boolean archivesOnly) {
-        filter = archivesOnly ? new JarFileFilter(filter) : filter;
-        File f = path.toFile();
-        if (f.isDirectory()) {
-            final File[] files = BootIOUtils.listFiles(f, filter);
-            for (File file : files)
-                this.files.add(file);
+    private ClasspathBuilder append(Path path, Predicate<Path> filter) {
+        if (Files.isDirectory(path)) {
+            try {
+                FileUtils.forEach(path, filter, files::add);
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to append files from " + path, e);
+            }
         } else {
-            if (filter == null || filter.accept(f))
-                files.add(f);
+            if (filter.test(path))
+                files.add(path);
         }
         return this;
     }
 
     public List<URL> toURLs() throws MalformedURLException {
-        List<URL> result = new ArrayList<URL>();
-        for (File file : files)
-            result.add(file.toURI().toURL());
+        List<URL> result = new ArrayList<>();
+        for (Path path : files)
+            result.add(path.toFile().toURI().toURL());
         return result;
     }
 
     public URL[] toURLsArray() throws MalformedURLException {
         List<URL> urls = toURLs();
-        return urls.toArray(new URL[urls.size()]);
+        return urls.toArray(new URL[0]);
     }
 
     public List<String> toFilesNames() {
-        List<String> result = new ArrayList<String>();
-        for (File file : files)
-            result.add(file.getAbsolutePath());
+        List<String> result = new ArrayList<>();
+        for (Path path : files)
+            result.add(path.toAbsolutePath().toString());
         return result;
     }
 
     @Override
     public String toString() {
         return String.join(File.pathSeparator, toFilesNames());
-    }
-
-    private static class JarFileFilter implements FileFilter {
-
-        private final FileFilter secondaryFilter;
-
-        private JarFileFilter(FileFilter secondaryFilter) {
-            this.secondaryFilter = secondaryFilter;
-        }
-
-        @Override
-        public boolean accept(File pathname) {
-            String filename = pathname.getName().toLowerCase();
-            if (filename.endsWith(".jar") || filename.endsWith(".zip")) {
-                return secondaryFilter != null ? secondaryFilter.accept(pathname) : true;
-            } else {
-                return false;
-            }
-        }
-    }
-
-    private static String path(String base, String subdir) {
-        return base + File.separator + subdir;
-    }
-
-    public static FileFilter startsWithFilter(final String... prefix) {
-        return new FileFilter() {
-            @Override
-            public boolean accept(File file) {
-                for (String p : prefix)
-                    if (file.getName().startsWith(p))
-                        return true;
-                return false;
-            }
-        };
     }
 }

--- a/xap-core/xap-common/src/main/java/org/jini/rio/boot/BootUtil.java
+++ b/xap-core/xap-common/src/main/java/org/jini/rio/boot/BootUtil.java
@@ -242,7 +242,7 @@ public class BootUtil {
     }
 
     public static List<URL> toURLs(String element) throws MalformedURLException {
-        return new ClasspathBuilder().append(Paths.get(element)).toURLs();
+        return new ClasspathBuilder().appendJars(Paths.get(element)).toURLs();
     }
 
     /**

--- a/xap-core/xap-openspaces/src/main/java/org/openspaces/pu/container/jee/JeeProcessingUnitContainerProvider.java
+++ b/xap-core/xap-openspaces/src/main/java/org/openspaces/pu/container/jee/JeeProcessingUnitContainerProvider.java
@@ -153,7 +153,7 @@ public abstract class JeeProcessingUnitContainerProvider extends ApplicationCont
     }
 
     protected Iterable<String> getWebAppClassLoaderClassPath() {
-        return new ClasspathBuilder().append(getJeeContainerJarPath(getJeeContainerType())).toFilesNames();
+        return new ClasspathBuilder().appendJars(getJeeContainerJarPath(getJeeContainerType())).toFilesNames();
     }
 
     protected ClassLoader getJeeClassLoader() throws Exception {


### PR DESCRIPTION
Goal is to unify lib/required jars handling by class loader type (system/common/service) instead of inconsistent hueristics (e.g. start with xap-)
- categorize lib/required jars by class loader type on startup.
- added SystemLocations.libRequired(ClassLoaderType) to get relevant paths.
- added ClasspathBuilder.addLibRequired(ClassLoaderType) to simplify class path building.
- refactored ClasspathBuilder.append to appendJars and appendAny to be more explicit on which files are appended.
- modified GsPremiumCommandFactory to use libRequired(System) instead of startsWith("slf4j")
- revamped PUServiceBeanImpl "WEB-INF/lib" construction to be simpler and more efficient.
- modified ClasspathBuilder usages to leverage new cl type functionality and naming