### PR TITLE
Correct EOLs for file containing expected result of unit test

### DIFF
--- a/xap-extensions/xap-blueprints/src/test/resources/samples/.gitattributes
+++ b/xap-extensions/xap-blueprints/src/test/resources/samples/.gitattributes
@@ -1,0 +1,4 @@
+# Git may (depending on user settings) convert the EOLs of "Person.java" to
+# the platform-native ones. But code generation always uses line feed (\n), so
+# the code generation test fails with other EOLs.
+Person.java text eol=lf


### PR DESCRIPTION
`BlueprintsTestCase` compares the generated text to the contents of `Person.java`. On systems using a different EOL than line feed, this will cause the test to fail.

The .gitattributes file forces Git to use the same line feed as the one used by the code generator.

Note: The CLA is on its way.