### PR TITLE
SQL functions must always use the English value formats

### DIFF
--- a/xap-core/xap-datagrid/src/main/java/com/gigaspaces/query/sql/functions/ToCharSqlFunction.java
+++ b/xap-core/xap-datagrid/src/main/java/com/gigaspaces/query/sql/functions/ToCharSqlFunction.java
@@ -17,8 +17,10 @@
 package com.gigaspaces.query.sql.functions;
 
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
 import java.util.TimeZone;
 
 /**
@@ -29,6 +31,8 @@ import java.util.TimeZone;
  */
 @com.gigaspaces.api.InternalApi
 public class ToCharSqlFunction extends SqlFunction {
+    public static final DecimalFormatSymbols DECIMAL_FORMAT_SYMBOLS = DecimalFormatSymbols.getInstance(Locale.ENGLISH);
+
     /**
      * @param context which contains a argument of type Number or Date and can have an additional
      *                format argument. A Number argument should be used with {@link DecimalFormat},
@@ -46,14 +50,14 @@ public class ToCharSqlFunction extends SqlFunction {
         }
         if (arg instanceof Number) {
             if (format != null) {
-                DecimalFormat decimalFormat = new DecimalFormat(String.valueOf(format));
+                DecimalFormat decimalFormat = new DecimalFormat(String.valueOf(format), DECIMAL_FORMAT_SYMBOLS);
                 return decimalFormat.format(arg);
             } else {
                 return arg;
             }
         } else if (arg instanceof Date) {
             if (format != null) {
-                SimpleDateFormat sdf = new SimpleDateFormat(String.valueOf(format));
+                SimpleDateFormat sdf = new SimpleDateFormat(String.valueOf(format), Locale.ENGLISH);
                 sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
                 return sdf.format(arg);
             }

--- a/xap-core/xap-datagrid/src/main/java/com/gigaspaces/query/sql/functions/ToNumberSqlFunction.java
+++ b/xap-core/xap-datagrid/src/main/java/com/gigaspaces/query/sql/functions/ToNumberSqlFunction.java
@@ -17,6 +17,8 @@
 package com.gigaspaces.query.sql.functions;
 
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
 
 /**
  * Built in conversion sql function to convert string type to Number.
@@ -26,6 +28,8 @@ import java.text.DecimalFormat;
  */
 @com.gigaspaces.api.InternalApi
 public class ToNumberSqlFunction extends SqlFunction {
+    public static final DecimalFormatSymbols DECIMAL_FORMAT_SYMBOLS = DecimalFormatSymbols.getInstance(Locale.ENGLISH);
+
     /**
      * @param context which contains an argument of type string and can have an additional format
      *                argument.
@@ -43,12 +47,12 @@ public class ToNumberSqlFunction extends SqlFunction {
             String str = String.valueOf(arg);
             if (format != null) { // with specific format
                 if (str.contains(".")) { //double
-                    DecimalFormat formatter = new DecimalFormat(String.valueOf(format));
+                    DecimalFormat formatter = new DecimalFormat(String.valueOf(format), DECIMAL_FORMAT_SYMBOLS);
                     double number = Double.parseDouble(String.valueOf(arg));
                     String numberFormatted = formatter.format(number);
                     return Double.parseDouble(numberFormatted);
                 } else { // int
-                    DecimalFormat formatter = new DecimalFormat(String.valueOf(format));
+                    DecimalFormat formatter = new DecimalFormat(String.valueOf(format), DECIMAL_FORMAT_SYMBOLS);
                     int number = Integer.parseInt(String.valueOf(arg));
                     String numberFormatted = formatter.format(number);
                     return Integer.parseInt(numberFormatted);


### PR DESCRIPTION
SQL code always uses the English notation to parse and display values. But these 2 SQL functions used the JVM default locale during parsing and displaying. The functions have been changed to always use English.

Note: The CLA is on its way.
