### PR TITLE
Switch to OpenJDK 8 on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 branches:
   only:


### PR DESCRIPTION
The way Oracle JDK 8 on Travis CI was used, is no longer supported. Switch to OpenJDK to make the build succeed again.

Note: The CLA is on its way.