### PR TITLE
PG system tables + PG infix cast + PG parameter syntax

### DIFF
--- a/xap-extensions/xap-aggregator-node/pom.xml
+++ b/xap-extensions/xap-aggregator-node/pom.xml
@@ -48,12 +48,6 @@
             <artifactId>xap-jdbc</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.github.jsqlparser</groupId>
-                    <artifactId>jsqlparser</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/query/PgTypeResolver.java
+++ b/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/query/PgTypeResolver.java
@@ -1,0 +1,23 @@
+package com.gigaspaces.sql.aggregatornode.netty.query;
+
+import com.gigaspaces.jdbc.calcite.GSTypeResolver;
+import com.gigaspaces.sql.aggregatornode.netty.utils.TypeUtils;
+import org.apache.calcite.rel.type.RelProtoDataType;
+
+import java.util.Set;
+
+public class PgTypeResolver implements GSTypeResolver {
+    public static final GSTypeResolver INSTANCE = new PgTypeResolver();
+
+    private PgTypeResolver() {}
+
+    @Override
+    public Set<String> registeredTypeNames() {
+        return TypeUtils.typeNames();
+    }
+
+    @Override
+    public RelProtoDataType resolveType(String name) {
+        return TypeUtils.resolveType(name);
+    }
+}

--- a/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/query/pgcatalog/IdGen.java
+++ b/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/query/pgcatalog/IdGen.java
@@ -1,0 +1,12 @@
+package com.gigaspaces.sql.aggregatornode.netty.query.pgcatalog;
+
+import java.util.HashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class IdGen {
+    private final AtomicInteger cntr = new AtomicInteger();
+    private final HashMap<String, Integer> items = new HashMap<>();
+    public int oid(String fqn) {
+        return items.computeIfAbsent(fqn, n -> cntr.incrementAndGet());
+    }
+}

--- a/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/query/pgcatalog/PgAmTable.java
+++ b/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/query/pgcatalog/PgAmTable.java
@@ -1,0 +1,20 @@
+package com.gigaspaces.sql.aggregatornode.netty.query.pgcatalog;
+
+import com.gigaspaces.sql.aggregatornode.netty.utils.TypeUtils;
+import com.j_spaces.core.IJSpace;
+
+public class PgAmTable extends PgCatalogTable {
+    public PgAmTable(IJSpace space) {
+        super(space, "pg_am");
+    }
+
+    @Override
+    protected void init(PgCatalogSchema parent) {
+        columns.add(new PgTableColumn("oid", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("amname", TypeUtils.resolveType("name"), this));
+        columns.add(new PgTableColumn("amhandler", TypeUtils.resolveType("regproc"), this));
+        columns.add(new PgTableColumn("amtype", TypeUtils.resolveType("char"), this));
+
+        super.init(parent);
+    }
+}

--- a/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/query/pgcatalog/PgAttributeTable.java
+++ b/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/query/pgcatalog/PgAttributeTable.java
@@ -1,0 +1,121 @@
+package com.gigaspaces.sql.aggregatornode.netty.query.pgcatalog;
+
+import com.gigaspaces.internal.metadata.ITypeDesc;
+import com.gigaspaces.internal.metadata.PropertyInfo;
+import com.gigaspaces.jdbc.model.QueryExecutionConfig;
+import com.gigaspaces.jdbc.model.result.QueryResult;
+import com.gigaspaces.jdbc.model.result.TableRow;
+import com.gigaspaces.jdbc.model.table.QueryColumn;
+import com.gigaspaces.sql.aggregatornode.netty.utils.PgType;
+import com.gigaspaces.sql.aggregatornode.netty.utils.TypeUtils;
+import com.j_spaces.core.IJSpace;
+import com.j_spaces.core.admin.IRemoteJSpaceAdmin;
+import com.j_spaces.jdbc.SQLUtil;
+import org.apache.calcite.schema.Table;
+import org.apache.calcite.sql.type.SqlTypeName;
+
+import java.rmi.RemoteException;
+import java.sql.SQLException;
+import java.util.Collection;
+import java.util.List;
+
+public class PgAttributeTable extends PgCatalogTable {
+    private final IdGen idGen;
+    private PgCatalogSchema parent;
+
+    public PgAttributeTable(IJSpace space, IdGen idGen) {
+        super(space, "pg_attribute");
+        this.idGen = idGen;
+    }
+
+    @Override
+    protected void init(PgCatalogSchema parent) {
+        this.parent = parent;
+
+        columns.add(new PgTableColumn("attrelid", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("attname", TypeUtils.resolveType("name"), this));
+        columns.add(new PgTableColumn("atttypid", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("attstattarget", TypeUtils.resolveType("int4"), this));
+        columns.add(new PgTableColumn("attlen", TypeUtils.resolveType("int2"), this));
+        columns.add(new PgTableColumn("attnum", TypeUtils.resolveType("int2"), this));
+        columns.add(new PgTableColumn("attndims", TypeUtils.resolveType("int4"), this));
+        columns.add(new PgTableColumn("attcacheoff", TypeUtils.resolveType("int4"), this));
+        columns.add(new PgTableColumn("atttypmod", TypeUtils.resolveType("int4"), this));
+        columns.add(new PgTableColumn("attbyval", TypeUtils.resolveType("bool"), this));
+        columns.add(new PgTableColumn("attstorage", TypeUtils.resolveType("char"), this));
+        columns.add(new PgTableColumn("attalign", TypeUtils.resolveType("char"), this));
+        columns.add(new PgTableColumn("attnotnull", TypeUtils.resolveType("bool"), this));
+        columns.add(new PgTableColumn("atthasdef", TypeUtils.resolveType("bool"), this));
+        columns.add(new PgTableColumn("attisdropped", TypeUtils.resolveType("bool"), this));
+        columns.add(new PgTableColumn("attislocal", TypeUtils.resolveType("bool"), this));
+        columns.add(new PgTableColumn("attinhcount", TypeUtils.resolveType("int4"), this));
+
+        super.init(parent);
+    }
+
+    @Override
+    protected QueryResult executeReadInternal(QueryExecutionConfig config) throws SQLException {
+        QueryResult result = super.executeReadInternal(config);
+        QueryColumn[] queryColumns = result.getQueryColumns().toArray(new QueryColumn[0]);
+
+        for (String name : getSpaceTables(space)) {
+            String fqn = "public." + name;
+            int oid = idGen.oid(fqn);
+            ITypeDesc typeDesc = SQLUtil.checkTableExistence(name, space);
+            short idx = 0;
+            for (PropertyInfo property : typeDesc.getProperties()) {
+                SqlTypeName sqlTypeName = mapToSqlType(property.getType());
+                PgType pgType = TypeUtils.fromInternal(sqlTypeName);
+
+                result.add(new TableRow(queryColumns, 
+                    oid, // attrelid
+                    property.getName(), // attname
+                    pgType.getId(), // atttypid
+                    0, // attstattarget
+                    (short)pgType.getLength(), // attlen
+                    ++idx,// attnum
+                    (pgType.getElementType() != 0 ? 1 : 0), // attndims
+                    -1, // attcacheoff
+                    -1, // atttypmod
+                    null, // attbyval
+                    'p', // attstorage
+                    'c', // attalign
+                    false, // attnotnull
+                    false, // atthasdef
+                    false, // attisdropped
+                    false, // attislocal
+                    0// attinhcount
+                ));
+            }
+        }
+
+        return result;
+    }
+
+    private List<String> getSpaceTables(IJSpace space) throws SQLException {
+        try {
+            return ((IRemoteJSpaceAdmin) space.getAdmin()).getRuntimeInfo().m_ClassNames;
+        } catch (RemoteException e) {
+            throw new SQLException("Failed to get runtime info from space", e);
+        }
+    }
+
+    private static SqlTypeName mapToSqlType(Class<?> clazz) {
+        if (clazz == Integer.class) {
+            return SqlTypeName.INTEGER;
+        } else if (clazz == Long.class) {
+            return SqlTypeName.BIGINT;
+        } else if (clazz == String.class) {
+            return SqlTypeName.VARCHAR;
+        } else if (clazz == java.util.Date.class) {
+            return SqlTypeName.DATE;
+        } else if (clazz == java.sql.Time.class) {
+            return SqlTypeName.TIME;
+        } else if (clazz == java.sql.Timestamp.class) {
+            return SqlTypeName.TIMESTAMP;
+        }
+
+
+        throw new UnsupportedOperationException("Unsupported type: " + clazz);
+    }
+}

--- a/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/query/pgcatalog/PgCatalogSchema.java
+++ b/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/query/pgcatalog/PgCatalogSchema.java
@@ -1,0 +1,58 @@
+package com.gigaspaces.sql.aggregatornode.netty.query.pgcatalog;
+
+import com.gigaspaces.jdbc.calcite.GSNamedSchema;
+import org.apache.calcite.schema.Table;
+import org.apache.calcite.schema.impl.AbstractSchema;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class PgCatalogSchema extends AbstractSchema implements GSNamedSchema {
+    private final PgCatalogTable[] tables;
+
+    public PgCatalogSchema(PgCatalogTable... tables) {
+        this.tables = tables;
+
+        for (PgCatalogTable table : tables) {
+            table.init(this);
+        }
+    }
+
+    public PgCatalogTable[] getTables() {
+        return tables;
+    }
+
+    @Override
+    public String getName() {
+        return "pg_catalog";
+    }
+
+    @Override
+    public boolean isDefault() {
+        return false;
+    }
+
+    @Override
+    public boolean isMutable() {
+        return false;
+    }
+
+    @Override
+    protected Map<String, Table> getTableMap() {
+        return Arrays.stream(tables)
+                .collect(Collectors.toMap(
+                        PgCatalogTable::getName,
+                        Function.identity(),
+                        PgCatalogSchema::firstNotNull));
+    }
+
+    @SafeVarargs
+    private static <T> T firstNotNull(T... values) {
+        for (T value : values) {
+            if (value != null)
+                return value;
+        }
+        return null;
+    }
+}

--- a/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/query/pgcatalog/PgCatalogTable.java
+++ b/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/query/pgcatalog/PgCatalogTable.java
@@ -1,0 +1,221 @@
+package com.gigaspaces.sql.aggregatornode.netty.query.pgcatalog;
+
+import com.gigaspaces.jdbc.calcite.GSTable;
+import com.gigaspaces.jdbc.exceptions.ColumnNotFoundException;
+import com.gigaspaces.jdbc.model.QueryExecutionConfig;
+import com.gigaspaces.jdbc.model.join.JoinInfo;
+import com.gigaspaces.jdbc.model.result.QueryResult;
+import com.gigaspaces.jdbc.model.result.TempTableQTP;
+import com.gigaspaces.jdbc.model.table.QueryColumn;
+import com.gigaspaces.jdbc.model.table.TableContainer;
+import com.j_spaces.core.IJSpace;
+import com.j_spaces.jdbc.builder.QueryTemplatePacket;
+import com.j_spaces.jdbc.builder.range.EqualValueRange;
+import com.j_spaces.jdbc.builder.range.Range;
+import com.j_spaces.jdbc.builder.range.SegmentRange;
+import org.apache.calcite.config.CalciteConnectionConfig;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.schema.Schema;
+import org.apache.calcite.schema.Statistic;
+import org.apache.calcite.schema.Statistics;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlNode;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public abstract class PgCatalogTable extends TableContainer implements GSTable {
+    protected final IJSpace space;
+    protected final String name;
+    protected final BitSet visible;
+    protected final List<PgTableColumn> columns;
+
+    private TempTableQTP queryTemplatePacket;
+
+    public PgCatalogTable(IJSpace space, String name) {
+        this.space = space;
+        this.name = name;
+        this.visible = new BitSet();
+        this.columns = new ArrayList<>();
+    }
+
+    protected void init(PgCatalogSchema parent) {
+        for (int i = 0; i < columns.size(); i++) {
+            PgTableColumn column = columns.get(i);
+            if (column.isVisible())
+                visible.set(i);
+        }
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    protected QueryResult executeReadInternal(QueryExecutionConfig config) throws SQLException {
+        return new QueryResult((List) columns);
+    }
+
+    @Override
+    public QueryResult executeRead(QueryExecutionConfig config) throws SQLException {
+        QueryResult queryResult = executeReadInternal(config);
+        if (queryTemplatePacket != null) {
+            queryResult.filter(x -> queryTemplatePacket.eval(x));
+        }
+        return new QueryResult(getVisibleColumns(), queryResult);
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public RelDataType getRowType(RelDataTypeFactory typeFactory) {
+        RelDataTypeFactory.Builder builder = new RelDataTypeFactory.Builder(typeFactory);
+        for (PgTableColumn column : columns) {
+            builder.add(column.getName(), column.sqlType(typeFactory));
+        }
+        return builder.build();
+    }
+
+    @Override
+    public TableContainer createTableContainer(IJSpace space) {
+        return this;
+    }
+
+    @Override
+    public List<String> getAllColumnNames() {
+        return columns.stream().map(QueryColumn::getName).collect(Collectors.toList());
+    }
+
+    @Override
+    public QueryColumn addQueryColumn(String columnName, String alias, boolean visible) {
+        int idx = -1;
+        for (int i = 0; i < columns.size(); i++) {
+            if (columns.get(i).getName().equalsIgnoreCase(columnName)) {
+                idx = i;
+                break;
+            }
+        }
+
+        if (idx == -1)
+            throw new ColumnNotFoundException("Could not find column with name [" + columnName + "]");
+
+        if (visible)
+            this.visible.set(idx);
+        else
+            this.visible.clear(idx);
+
+        return columns.get(idx);
+    }
+
+    @Override
+    public String getTableNameOrAlias() {
+        return name;
+    }
+
+    @Override
+    public List<QueryColumn> getVisibleColumns() {
+        return visible.stream()
+                .mapToObj(columns::get)
+                .map(QueryColumn.class::cast)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void setQueryTemplatePacket(QueryTemplatePacket queryTemplatePacket) {
+        this.queryTemplatePacket = ((TempTableQTP) queryTemplatePacket);
+    }
+
+    @Override
+    public void setLimit(Integer value) {
+        throw new UnsupportedOperationException("Not supported yet!");
+    }
+
+    @Override
+    public QueryTemplatePacket createQueryTemplatePacketWithRange(Range range) {
+        addQueryColumn(range.getPath(), null, false);
+        if (range instanceof EqualValueRange) {
+            return new TempTableQTP((EqualValueRange) range);
+        } else if (range instanceof SegmentRange) {
+            return new TempTableQTP((SegmentRange) range);
+        } else {
+            throw new UnsupportedOperationException("Range: " + range);
+        }
+    }
+
+    @Override
+    public Object getColumnValue(String columnName, Object value) {
+        return value;
+    }
+
+    @Override
+    public TableContainer getJoinedTable() {
+        throw new UnsupportedOperationException("Not supported yet!");
+    }
+
+    @Override
+    public void setJoinedTable(TableContainer joinedTable) {
+        throw new UnsupportedOperationException("Not supported yet!");
+    }
+
+    @Override
+    public QueryResult getQueryResult() {
+        throw new UnsupportedOperationException("Not supported yet!");
+    }
+
+    @Override
+    public void setJoined(boolean joined) {
+        throw new UnsupportedOperationException("Not supported yet!");
+    }
+
+    @Override
+    public boolean isJoined() {
+        throw new UnsupportedOperationException("Not supported yet!");
+    }
+
+    @Override
+    public boolean hasColumn(String columnName) {
+        return getAllColumnNames().contains(columnName);
+    }
+
+    @Override
+    public JoinInfo getJoinInfo() {
+        throw new UnsupportedOperationException("Not supported yet!");
+    }
+
+    @Override
+    public void setJoinInfo(JoinInfo joinInfo) {
+        throw new UnsupportedOperationException("Not supported yet!");
+    }
+
+    @Override
+    public boolean checkJoinCondition() {
+        throw new UnsupportedOperationException("Not supported yet!");
+    }
+
+    // Default implementation. Override if you have statistics.
+    public Statistic getStatistic() {
+        return Statistics.UNKNOWN;
+    }
+
+    public Schema.TableType getJdbcTableType() {
+        return Schema.TableType.TABLE;
+    }
+
+    public <C> C unwrap(Class<C> aClass) {
+        if (aClass.isInstance(this)) {
+            return aClass.cast(this);
+        }
+        return null;
+    }
+
+    @Override public boolean isRolledUp(String column) {
+        return false;
+    }
+
+    @Override public boolean rolledUpColumnValidInsideAgg(String column, SqlCall call, SqlNode parent, CalciteConnectionConfig config) {
+        return true;
+    }
+}

--- a/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/query/pgcatalog/PgClassTable.java
+++ b/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/query/pgcatalog/PgClassTable.java
@@ -1,0 +1,100 @@
+package com.gigaspaces.sql.aggregatornode.netty.query.pgcatalog;
+
+import com.gigaspaces.internal.metadata.ITypeDesc;
+import com.gigaspaces.jdbc.model.QueryExecutionConfig;
+import com.gigaspaces.jdbc.model.result.QueryResult;
+import com.gigaspaces.jdbc.model.result.TableRow;
+import com.gigaspaces.jdbc.model.table.QueryColumn;
+import com.gigaspaces.sql.aggregatornode.netty.utils.TypeUtils;
+import com.j_spaces.core.IJSpace;
+import com.j_spaces.core.admin.IRemoteJSpaceAdmin;
+import com.j_spaces.jdbc.SQLUtil;
+
+import java.rmi.RemoteException;
+import java.sql.SQLException;
+import java.util.List;
+
+public class PgClassTable extends PgCatalogTable {
+    private final IdGen idGen;
+
+    public PgClassTable(IJSpace space, IdGen idGen) {
+        super(space, "pg_class");
+        this.idGen = idGen;
+    }
+
+    @Override
+    protected void init(PgCatalogSchema parent) {
+        columns.add(new PgTableColumn("oid", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("relname", TypeUtils.resolveType("name"), this));
+        columns.add(new PgTableColumn("relnamespace", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("reltype", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("relowner", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("relam", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("relfilenode", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("reltablespace", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("relpages", TypeUtils.resolveType("int4"), this));
+        columns.add(new PgTableColumn("reltuples", TypeUtils.resolveType("float4"), this));
+        columns.add(new PgTableColumn("reltoastrelid", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("relhasindex", TypeUtils.resolveType("bool"), this));
+        columns.add(new PgTableColumn("relisshared", TypeUtils.resolveType("bool"), this));
+        columns.add(new PgTableColumn("relkind", TypeUtils.resolveType("char"), this));
+        columns.add(new PgTableColumn("relnatts", TypeUtils.resolveType("int2"), this));
+        columns.add(new PgTableColumn("relchecks", TypeUtils.resolveType("int2"), this));
+        columns.add(new PgTableColumn("reltriggers", TypeUtils.resolveType("int2"), this));
+        columns.add(new PgTableColumn("relhasrules", TypeUtils.resolveType("bool"), this));
+        columns.add(new PgTableColumn("relhastriggers", TypeUtils.resolveType("bool"), this));
+        columns.add(new PgTableColumn("relhassubclass", TypeUtils.resolveType("bool"), this));
+        columns.add(new PgTableColumn("relacl", TypeUtils.resolveType("aclitem_array"), this));
+        columns.add(new PgTableColumn("reloptions", TypeUtils.resolveType("text_array"), this));
+
+        super.init(parent);
+    }
+
+    @Override
+    protected QueryResult executeReadInternal(QueryExecutionConfig config) throws SQLException {
+        QueryResult result = super.executeReadInternal(config);
+        QueryColumn[] queryColumns = result.getQueryColumns().toArray(new QueryColumn[0]);
+
+        for (String name : getSpaceTables(space)) {
+            String fqn = "public." + name;
+            int oid = idGen.oid(fqn);
+            ITypeDesc typeDesc = SQLUtil.checkTableExistence(name, space);
+            result.add(new TableRow(queryColumns,
+                oid,//    oid
+                name,//    relname
+                PgNamespaceTable.NS_PUBLIC_OID,//    relnamespace
+                0,//    reltype
+                0,//    relowner
+                0,//    relam
+                0,//    relfilenode
+                0,//    reltablespace
+                0,//    relpages
+                100.0f,//    reltuples
+                0,//    reltoastrelid
+                false,//    relhasindex
+                false,//    relisshared
+                'r',//    relkind
+                (short) typeDesc.getProperties().length, //    relnatts
+                (short) 0,//    relchecks
+                (short) 0,//    reltriggers
+                false, //    relhasrules
+                false, //    relhastriggers
+                false, //    relhassubclass
+                null, // relacl
+                null//    reloptions
+            ));
+        }
+
+
+
+        return result;
+    }
+
+    private List<String> getSpaceTables(IJSpace space) throws SQLException {
+        try {
+            return ((IRemoteJSpaceAdmin) space.getAdmin()).getRuntimeInfo().m_ClassNames;
+        } catch (RemoteException e) {
+            throw new SQLException("Failed to get runtime info from space", e);
+        }
+    }
+}

--- a/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/query/pgcatalog/PgConstraintTable.java
+++ b/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/query/pgcatalog/PgConstraintTable.java
@@ -1,0 +1,41 @@
+package com.gigaspaces.sql.aggregatornode.netty.query.pgcatalog;
+
+import com.gigaspaces.sql.aggregatornode.netty.utils.TypeUtils;
+import com.j_spaces.core.IJSpace;
+
+public class PgConstraintTable extends PgCatalogTable {
+    public PgConstraintTable(IJSpace space) {
+        super(space, "pg_constraint");
+    }
+
+    @Override
+    protected void init(PgCatalogSchema parent) {
+        columns.add(new PgTableColumn("oid", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("conname", TypeUtils.resolveType("name"), this));
+        columns.add(new PgTableColumn("connamespace", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("contype", TypeUtils.resolveType("char"), this));
+        columns.add(new PgTableColumn("condeferrable", TypeUtils.resolveType("bool"), this));
+        columns.add(new PgTableColumn("condeferred", TypeUtils.resolveType("bool"), this));
+        columns.add(new PgTableColumn("convalidated", TypeUtils.resolveType("bool"), this));
+        columns.add(new PgTableColumn("conrelid", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("contypid", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("conindid", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("conparentid", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("confrelid", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("confupdtype", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("confdeltype", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("confmatchtype", TypeUtils.resolveType("char"), this));
+        columns.add(new PgTableColumn("conislocal", TypeUtils.resolveType("char"), this));
+        columns.add(new PgTableColumn("coninhcount", TypeUtils.resolveType("char"), this));
+        columns.add(new PgTableColumn("connoinherit", TypeUtils.resolveType("bool"), this));
+        columns.add(new PgTableColumn("conkey", TypeUtils.resolveType("int2_array"), this));
+        columns.add(new PgTableColumn("confkey", TypeUtils.resolveType("int2_array"), this));
+        columns.add(new PgTableColumn("conpfeqop", TypeUtils.resolveType("oid_array"), this));
+        columns.add(new PgTableColumn("conppeqop", TypeUtils.resolveType("oid_array"), this));
+        columns.add(new PgTableColumn("conffeqop", TypeUtils.resolveType("oid_array"), this));
+        columns.add(new PgTableColumn("conexclop", TypeUtils.resolveType("oid_array"), this));
+        columns.add(new PgTableColumn("conbin", TypeUtils.resolveType("pg_node_tree"), this));
+
+        super.init(parent);
+    }
+}

--- a/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/query/pgcatalog/PgDatabaseTable.java
+++ b/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/query/pgcatalog/PgDatabaseTable.java
@@ -1,0 +1,30 @@
+package com.gigaspaces.sql.aggregatornode.netty.query.pgcatalog;
+
+import com.gigaspaces.sql.aggregatornode.netty.utils.TypeUtils;
+import com.j_spaces.core.IJSpace;
+
+public class PgDatabaseTable extends PgCatalogTable {
+    public PgDatabaseTable(IJSpace space) {
+        super(space, "pg_database");
+    }
+
+    @Override
+    protected void init(PgCatalogSchema parent) {
+        columns.add(new PgTableColumn("oid", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("datname", TypeUtils.resolveType("name"), this));
+        columns.add(new PgTableColumn("datdba", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("encoding", TypeUtils.resolveType("int4"), this));
+        columns.add(new PgTableColumn("datcollate", TypeUtils.resolveType("name"), this));
+        columns.add(new PgTableColumn("datctype", TypeUtils.resolveType("name"), this));
+        columns.add(new PgTableColumn("datistemplate", TypeUtils.resolveType("bool"), this));
+        columns.add(new PgTableColumn("datallowconn", TypeUtils.resolveType("bool"), this));
+        columns.add(new PgTableColumn("datconnlimit", TypeUtils.resolveType("int4"), this));
+        columns.add(new PgTableColumn("datlastsysoid", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("datfrozenxid", TypeUtils.resolveType("xid"), this));
+        columns.add(new PgTableColumn("datminmxid", TypeUtils.resolveType("xid"), this));
+        columns.add(new PgTableColumn("dattablespace", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("datacl", TypeUtils.resolveType("aclitem_array"), this));
+
+        super.init(parent);
+    }
+}

--- a/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/query/pgcatalog/PgIndexTable.java
+++ b/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/query/pgcatalog/PgIndexTable.java
@@ -1,0 +1,37 @@
+package com.gigaspaces.sql.aggregatornode.netty.query.pgcatalog;
+
+import com.gigaspaces.sql.aggregatornode.netty.utils.TypeUtils;
+import com.j_spaces.core.IJSpace;
+
+public class PgIndexTable extends PgCatalogTable {
+    public PgIndexTable(IJSpace space) {
+        super(space, "pg_index");
+    }
+
+    @Override
+    protected void init(PgCatalogSchema parent) {
+        columns.add(new PgTableColumn("oid", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("indexrelid", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("indrelid", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("indnatts", TypeUtils.resolveType("int2"), this));
+        columns.add(new PgTableColumn("indnkeyatts", TypeUtils.resolveType("int2"), this));
+        columns.add(new PgTableColumn("indisunique", TypeUtils.resolveType("bool"), this));
+        columns.add(new PgTableColumn("indisprimary", TypeUtils.resolveType("bool"), this));
+        columns.add(new PgTableColumn("indisexclusion", TypeUtils.resolveType("bool"), this));
+        columns.add(new PgTableColumn("indimmediate", TypeUtils.resolveType("bool"), this));
+        columns.add(new PgTableColumn("indisclustered", TypeUtils.resolveType("bool"), this));
+        columns.add(new PgTableColumn("indisvalid", TypeUtils.resolveType("bool"), this));
+        columns.add(new PgTableColumn("indcheckxmin", TypeUtils.resolveType("bool"), this));
+        columns.add(new PgTableColumn("indisready", TypeUtils.resolveType("bool"), this));
+        columns.add(new PgTableColumn("indislive", TypeUtils.resolveType("bool"), this));
+        columns.add(new PgTableColumn("indisreplident", TypeUtils.resolveType("bool"), this));
+        columns.add(new PgTableColumn("indkey", TypeUtils.resolveType("int2vector"), this));
+        columns.add(new PgTableColumn("indcollation", TypeUtils.resolveType("oidvector"), this));
+        columns.add(new PgTableColumn("indclass", TypeUtils.resolveType("oidvector"), this));
+        columns.add(new PgTableColumn("indoption", TypeUtils.resolveType("int2vector"), this));
+        columns.add(new PgTableColumn("indexprs", TypeUtils.resolveType("pg_node_tree"), this));
+        columns.add(new PgTableColumn("indpred", TypeUtils.resolveType("pg_node_tree"), this));
+
+        super.init(parent);
+    }
+}

--- a/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/query/pgcatalog/PgNamespaceTable.java
+++ b/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/query/pgcatalog/PgNamespaceTable.java
@@ -1,0 +1,38 @@
+package com.gigaspaces.sql.aggregatornode.netty.query.pgcatalog;
+
+import com.gigaspaces.jdbc.model.QueryExecutionConfig;
+import com.gigaspaces.jdbc.model.result.QueryResult;
+import com.gigaspaces.jdbc.model.result.TableRow;
+import com.gigaspaces.jdbc.model.table.QueryColumn;
+import com.gigaspaces.sql.aggregatornode.netty.utils.TypeUtils;
+import com.j_spaces.core.IJSpace;
+
+import java.sql.SQLException;
+
+public class PgNamespaceTable extends PgCatalogTable {
+    public static final int NS_PUBLIC_OID = 0;
+    public static final int NS_PG_CATALOG_OID = -1000;
+
+    public PgNamespaceTable(IJSpace space) {
+        super(space, "pg_namespace");
+    }
+
+    @Override
+    protected void init(PgCatalogSchema parent) {
+        columns.add(new PgTableColumn("oid", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("nspname", TypeUtils.resolveType("name"), this));
+        columns.add(new PgTableColumn("nspowner", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("nspacl", TypeUtils.resolveType("aclitem_array"), this));
+
+        super.init(parent);
+    }
+
+    @Override
+    protected QueryResult executeReadInternal(QueryExecutionConfig config) throws SQLException {
+        QueryResult result = super.executeReadInternal(config);
+        QueryColumn[] queryColumns = result.getQueryColumns().toArray(new QueryColumn[0]);
+        result.add(new TableRow(queryColumns, NS_PUBLIC_OID, "PUBLIC", 0, null));
+        result.add(new TableRow(queryColumns, NS_PG_CATALOG_OID, "PG_CATALOG", 0, null));
+        return result;
+    }
+}

--- a/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/query/pgcatalog/PgProcTable.java
+++ b/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/query/pgcatalog/PgProcTable.java
@@ -1,0 +1,45 @@
+package com.gigaspaces.sql.aggregatornode.netty.query.pgcatalog;
+
+import com.gigaspaces.sql.aggregatornode.netty.utils.TypeUtils;
+import com.j_spaces.core.IJSpace;
+
+public class PgProcTable extends PgCatalogTable {
+    public PgProcTable(IJSpace space) {
+        super(space, "pg_proc");
+    }
+
+    @Override
+    protected void init(PgCatalogSchema parent) {
+        columns.add(new PgTableColumn("oid", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("proname", TypeUtils.resolveType("name"), this));
+        columns.add(new PgTableColumn("pronamespace", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("proowner", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("prolang", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("procost", TypeUtils.resolveType("float4"), this));
+        columns.add(new PgTableColumn("prorows", TypeUtils.resolveType("float4"), this));
+        columns.add(new PgTableColumn("provariadic", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("prosupport", TypeUtils.resolveType("regproc"), this));
+        columns.add(new PgTableColumn("prokind", TypeUtils.resolveType("char"), this));
+        columns.add(new PgTableColumn("prosecdef", TypeUtils.resolveType("bool"), this));
+        columns.add(new PgTableColumn("proleakproof", TypeUtils.resolveType("bool"), this));
+        columns.add(new PgTableColumn("proisstrict", TypeUtils.resolveType("bool"), this));
+        columns.add(new PgTableColumn("proretset", TypeUtils.resolveType("bool"), this));
+        columns.add(new PgTableColumn("provolatile", TypeUtils.resolveType("char"), this));
+        columns.add(new PgTableColumn("proparallel", TypeUtils.resolveType("char"), this));
+        columns.add(new PgTableColumn("pronargs", TypeUtils.resolveType("int2"), this));
+        columns.add(new PgTableColumn("pronargdefaults", TypeUtils.resolveType("int2"), this));
+        columns.add(new PgTableColumn("prorettype", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("proargtypes", TypeUtils.resolveType("oidvector"), this));
+        columns.add(new PgTableColumn("proallargtypes", TypeUtils.resolveType("oid_array"), this));
+        columns.add(new PgTableColumn("proargmodes", TypeUtils.resolveType("char_array"), this));
+        columns.add(new PgTableColumn("proargnames", TypeUtils.resolveType("text_array"), this));
+        columns.add(new PgTableColumn("proargdefaults", TypeUtils.resolveType("pg_node_tree"), this));
+        columns.add(new PgTableColumn("protrftypes", TypeUtils.resolveType("oid_array"), this));
+        columns.add(new PgTableColumn("prosrc", TypeUtils.resolveType("text"), this));
+        columns.add(new PgTableColumn("probin", TypeUtils.resolveType("text"), this));
+        columns.add(new PgTableColumn("proconfig", TypeUtils.resolveType("text_array"), this));
+        columns.add(new PgTableColumn("proacl", TypeUtils.resolveType("aclitem_array"), this));
+
+        super.init(parent);
+    }
+}

--- a/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/query/pgcatalog/PgTableColumn.java
+++ b/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/query/pgcatalog/PgTableColumn.java
@@ -1,0 +1,24 @@
+package com.gigaspaces.sql.aggregatornode.netty.query.pgcatalog;
+
+import com.gigaspaces.jdbc.model.table.QueryColumn;
+import com.gigaspaces.jdbc.model.table.TableContainer;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelProtoDataType;
+
+public class PgTableColumn extends QueryColumn {
+    private final RelProtoDataType sqlType;
+
+    public PgTableColumn(String name, RelProtoDataType sqlType, TableContainer tableContainer) {
+        this(name, null, sqlType, true, tableContainer);
+    }
+
+    public PgTableColumn(String name, String alias, RelProtoDataType sqlType, boolean isVisible, TableContainer tableContainer) {
+        super(name, alias, isVisible, tableContainer);
+        this.sqlType = sqlType;
+    }
+
+    public RelDataType sqlType(RelDataTypeFactory typeFactory) {
+        return sqlType.apply(typeFactory);
+    }
+}

--- a/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/query/pgcatalog/PgTriggerTable.java
+++ b/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/query/pgcatalog/PgTriggerTable.java
@@ -1,0 +1,35 @@
+package com.gigaspaces.sql.aggregatornode.netty.query.pgcatalog;
+
+import com.gigaspaces.sql.aggregatornode.netty.utils.TypeUtils;
+import com.j_spaces.core.IJSpace;
+
+public class PgTriggerTable extends PgCatalogTable {
+    public PgTriggerTable(IJSpace space) {
+        super(space, "pg_trigger");
+    }
+
+    @Override
+    protected void init(PgCatalogSchema parent) {
+        columns.add(new PgTableColumn("oid", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("tgrelid", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("tgparentid", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("tgname", TypeUtils.resolveType("name"), this));
+        columns.add(new PgTableColumn("tgfoid", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("tgtype", TypeUtils.resolveType("int2"), this));
+        columns.add(new PgTableColumn("tgenabled", TypeUtils.resolveType("char"), this));
+        columns.add(new PgTableColumn("tgisinternal", TypeUtils.resolveType("bool"), this));
+        columns.add(new PgTableColumn("tgconstrrelid", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("tgconstrindid", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("tgconstraint", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("tgdeferrable", TypeUtils.resolveType("bool"), this));
+        columns.add(new PgTableColumn("tginitdeferred", TypeUtils.resolveType("bool"), this));
+        columns.add(new PgTableColumn("tgnargs", TypeUtils.resolveType("int2"), this));
+        columns.add(new PgTableColumn("tgattr", TypeUtils.resolveType("int2vector"), this));
+        columns.add(new PgTableColumn("tgargs", TypeUtils.resolveType("bytea"), this));
+        columns.add(new PgTableColumn("tgqual", TypeUtils.resolveType("pg_node_tree"), this));
+        columns.add(new PgTableColumn("tgoldtable", TypeUtils.resolveType("name"), this));
+        columns.add(new PgTableColumn("tgnewtable", TypeUtils.resolveType("name"), this));
+
+        super.init(parent);
+    }
+}

--- a/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/query/pgcatalog/PgTypeTable.java
+++ b/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/query/pgcatalog/PgTypeTable.java
@@ -1,0 +1,87 @@
+package com.gigaspaces.sql.aggregatornode.netty.query.pgcatalog;
+
+import com.gigaspaces.jdbc.model.QueryExecutionConfig;
+import com.gigaspaces.jdbc.model.result.QueryResult;
+import com.gigaspaces.jdbc.model.result.TableRow;
+import com.gigaspaces.jdbc.model.table.QueryColumn;
+import com.gigaspaces.sql.aggregatornode.netty.utils.Constants;
+import com.gigaspaces.sql.aggregatornode.netty.utils.PgType;
+import com.gigaspaces.sql.aggregatornode.netty.utils.TypeUtils;
+import com.j_spaces.core.IJSpace;
+
+import java.sql.SQLException;
+
+public class PgTypeTable extends PgCatalogTable {
+    public PgTypeTable(IJSpace space) {
+        super(space, "pg_type");
+    }
+
+    @Override
+    protected void init(PgCatalogSchema parent) {
+        columns.add(new PgTableColumn("oid", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("typname", TypeUtils.resolveType("name"), this));
+        columns.add(new PgTableColumn("typnamespace", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("typowner", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("typlen", TypeUtils.resolveType("int2"), this));
+        columns.add(new PgTableColumn("typbyval", TypeUtils.resolveType("bool"), this));
+        columns.add(new PgTableColumn("typtype", TypeUtils.resolveType("char"), this));
+        columns.add(new PgTableColumn("typisdefined", TypeUtils.resolveType("bool"), this));
+        columns.add(new PgTableColumn("typdelim", TypeUtils.resolveType("char"), this));
+        columns.add(new PgTableColumn("typrelid", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("typelem", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("typinput", TypeUtils.resolveType("regproc"), this));
+        columns.add(new PgTableColumn("typoutput", TypeUtils.resolveType("regproc"), this));
+        columns.add(new PgTableColumn("typreceive", TypeUtils.resolveType("regproc"), this));
+        columns.add(new PgTableColumn("typsend", TypeUtils.resolveType("regproc"), this));
+        columns.add(new PgTableColumn("typanalyze", TypeUtils.resolveType("regproc"), this));
+        columns.add(new PgTableColumn("typalign", TypeUtils.resolveType("char"), this));
+        columns.add(new PgTableColumn("typstorage", TypeUtils.resolveType("char"), this));
+        columns.add(new PgTableColumn("typnotnull", TypeUtils.resolveType("bool"), this));
+        columns.add(new PgTableColumn("typbasetype", TypeUtils.resolveType("oid"), this));
+        columns.add(new PgTableColumn("typtypmod", TypeUtils.resolveType("int4"), this));
+        columns.add(new PgTableColumn("typndims", TypeUtils.resolveType("int4"), this));
+        columns.add(new PgTableColumn("typdefaultbin", TypeUtils.resolveType("pg_node_tree"), this));
+        columns.add(new PgTableColumn("typdefault", TypeUtils.resolveType("text"), this));
+
+        super.init(parent);
+    }
+
+    @Override
+    protected QueryResult executeReadInternal(QueryExecutionConfig config) throws SQLException {
+        QueryResult result = super.executeReadInternal(config);
+
+        QueryColumn[] queryColumns = result.getQueryColumns().toArray(new QueryColumn[0]);
+
+        for (PgType type : TypeUtils.types()) {
+            TableRow row = new TableRow(queryColumns,
+                    type.getId(), //            oid
+                    type.getName(), //            typname
+                    PgNamespaceTable.NS_PG_CATALOG_OID, //            typnamespace
+                    0,//            typowner
+                    (short) type.getLength(),//            typlen
+                    null,//            typbyval
+                    'b',//            typtype
+                    true, //            typisdefined
+                    Constants.DELIMITER, //            typdelim
+                    0, //            typrelid
+                    type.getElementType() , //            typelem
+                    0, //            typinput
+                    0, //            typoutput
+                    0, //            typreceive
+                    0, //            typsend
+                    0, //            typanalyze
+                    'c', //            typalign
+                    'p', //            typstorage
+                    false, //            typnotnull
+                    0, //            typbasetype
+                    -1, //            typtypmod
+                    (type.getElementType() != 0 ? 1 : 0), //            typndims
+                    null, //            typdefaultbin
+                    null//            typdefault
+            );
+
+            result.add(row);
+        }
+        return result;
+    }
+}

--- a/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/query/pgcatalog/TableInfo.java
+++ b/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/query/pgcatalog/TableInfo.java
@@ -1,0 +1,5 @@
+package com.gigaspaces.sql.aggregatornode.netty.query.pgcatalog;
+
+public class TableInfo {
+
+}

--- a/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/utils/Constants.java
+++ b/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/utils/Constants.java
@@ -23,7 +23,7 @@ public class Constants {
     public static final int[] EMPTY_INT_ARRAY = new int[0];
     public static final String EMPTY_STRING = "";
 
-    public static final String DELIMITER = ",";
+    public static final char DELIMITER = ',';
 
     private Constants() {}
 }

--- a/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/utils/PgType.java
+++ b/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/utils/PgType.java
@@ -32,6 +32,10 @@ public abstract class PgType {
         return length;
     }
 
+    public int getElementType() {
+        return elementType;
+    }
+
     protected final void asText(Session session, ByteBuf dst, Object value) throws ProtocolException {
         if (TypeUtils.writeNull(dst, value))
             return;

--- a/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/utils/PgTypeArray.java
+++ b/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/utils/PgTypeArray.java
@@ -1,0 +1,183 @@
+package com.gigaspaces.sql.aggregatornode.netty.utils;
+
+import com.gigaspaces.sql.aggregatornode.netty.exception.BreakingException;
+import com.gigaspaces.sql.aggregatornode.netty.exception.NonBreakingException;
+import com.gigaspaces.sql.aggregatornode.netty.exception.ProtocolException;
+import com.gigaspaces.sql.aggregatornode.netty.query.Session;
+import io.netty.buffer.ByteBuf;
+
+import java.util.ArrayList;
+
+import static com.gigaspaces.sql.aggregatornode.netty.utils.Constants.DELIMITER;
+
+public class PgTypeArray<E> extends PgType {
+    protected PgTypeArray(int id, String name, int length, int arrayType, int elementType) {
+        super(id, name, length, arrayType, elementType);
+    }
+
+    @Override
+    protected void asTextInternal(Session session, ByteBuf dst, Object value) throws ProtocolException {
+        Object[] values;
+        try {
+            values = (Object[]) value;
+        } catch (Exception e) {
+            throw new BreakingException(ErrorCodes.PROTOCOL_VIOLATION, "Unexpected value type: " + value.getClass());
+        }
+
+        StringBuilder sb = new StringBuilder();
+
+        sb.append('{');
+        for (int i = 0; i < values.length; i++) {
+            if (i > 0)
+                sb.append(DELIMITER);
+            sb.append(asText(session, cast(values[i])));
+        }
+        sb.append('}');
+
+        TypeUtils.writeText(session, dst, sb.toString());
+    }
+
+    @Override
+    protected <T> T fromTextInternal(Session session, ByteBuf src) throws ProtocolException {
+        ArrayList<E> values = new ArrayList<>();
+        char[] chars = TypeUtils.readText(session, src).toCharArray();
+        StringBuilder sb = new StringBuilder();
+        boolean arrayOpened = false;
+        boolean arrayClosed = false;
+        int startOffset = 0;
+        if (chars[0] == '[') {
+            while (chars[startOffset] != '=') {
+                startOffset++;
+            }
+            startOffset++; // skip =
+        }
+        for (int i = startOffset; i < chars.length; i++) {
+            char ch = chars[i];
+            if (Character.isWhitespace(ch))
+                continue;
+
+            switch (ch) {
+                case '{': {
+                    if (arrayClosed)
+                        throw new NonBreakingException(ErrorCodes.PROTOCOL_VIOLATION, "Unexpected array start");
+                    if (arrayOpened)
+                        throw new NonBreakingException(ErrorCodes.UNSUPPORTED_FEATURE, "Multidimensional arrays are unsupported");
+
+                    arrayOpened = true;
+
+                    break;
+                }
+
+                case '}': {
+                    if (!arrayOpened || arrayClosed)
+                        throw new NonBreakingException(ErrorCodes.PROTOCOL_VIOLATION, "Unexpected array end");
+
+                    arrayClosed = true;
+                    if (sb.length() > 0)
+                        values.add(parseText(session, sb.toString()));
+
+                    sb.setLength(0);
+
+                    break;
+                }
+
+                case DELIMITER: {
+                    if (!arrayOpened || arrayClosed || sb.length() == 0)
+                        throw new NonBreakingException(ErrorCodes.PROTOCOL_VIOLATION, "Unexpected array delimiter");
+
+                    values.add(parseText(session, sb.toString()));
+                    sb.setLength(0);
+
+                    break;
+                }
+
+                default:
+                    sb.append(ch);
+                    break;
+            }
+        }
+
+        if (!arrayOpened || !arrayClosed)
+            throw new NonBreakingException(ErrorCodes.PROTOCOL_VIOLATION, "Failed to read value");
+
+        return (T) values.toArray();
+    }
+
+    @Override
+    protected void asBinaryInternal(Session session, ByteBuf dst, Object value) throws ProtocolException {
+        Object[] values;
+        try {
+            values = (Object[]) value;
+        } catch (Exception e) {
+            throw new BreakingException(ErrorCodes.PROTOCOL_VIOLATION, "Unexpected value type: " + value.getClass());
+        }
+
+        int idx = dst.writerIndex();
+        dst.writeInt(0); // column len
+
+        dst.writeInt(1); // dimensions
+        dst.writeInt(countNulls(values)); // nulls
+        dst.writeInt(elementType); // element type
+        dst.writeInt(values.length); // length
+        dst.writeInt(1); // base
+        for (Object value0 : values) {
+            writeBinary(session, cast(value0), dst);
+        }
+
+        dst.setInt(idx, dst.writerIndex() - idx - 4);
+    }
+
+    @Override
+    protected <T> T fromBinaryInternal(Session session, ByteBuf src) throws ProtocolException {
+        int end = src.readInt() + src.writerIndex();
+        if (src.readInt() != 1)
+            throw new NonBreakingException(ErrorCodes.UNSUPPORTED_FEATURE, "Multidimensional arrays are unsupported");
+        src.skipBytes(4); // null element count
+        if (src.readInt() != elementType)
+            throw new NonBreakingException(ErrorCodes.PROTOCOL_VIOLATION, "unexpected element type");
+        int length = src.readInt();
+        ArrayList<E> values = new ArrayList<>(length);
+        src.skipBytes(4); // base
+        for (int i = 0; i < length; i++) {
+            values.add(readBinary(session, src));
+        }
+        if (src.writerIndex() != end)
+            throw new NonBreakingException(ErrorCodes.PROTOCOL_VIOLATION, "Failed to read value");
+
+        return (T) values.toArray();
+    }
+
+    protected String asText(Session session, E value) throws ProtocolException {
+        throw new BreakingException(ErrorCodes.INTERNAL_ERROR, "Unsupported data type: " + elementType);
+    }
+
+    protected E parseText(Session session, String src) throws ProtocolException {
+        throw new BreakingException(ErrorCodes.INTERNAL_ERROR, "Unsupported data type: " + elementType);
+    }
+
+    protected void writeBinary(Session session, E value, ByteBuf dst) throws ProtocolException {
+        throw new BreakingException(ErrorCodes.INTERNAL_ERROR, "Unsupported data type: " + elementType);
+    }
+
+    protected E readBinary(Session session, ByteBuf src) throws ProtocolException {
+        throw new BreakingException(ErrorCodes.INTERNAL_ERROR, "Unsupported data type: " + elementType);
+    }
+
+    @SuppressWarnings("unchecked")
+    private E cast(Object value0) throws BreakingException {
+        try {
+            return (E) value0;
+        } catch (Exception e) {
+            throw new BreakingException(ErrorCodes.PROTOCOL_VIOLATION, "Unexpected value type: " + value0.getClass());
+        }
+    }
+
+    private int countNulls(Object[] values) {
+        int res = 0;
+        for (Object value : values) {
+            if (value == null)
+                res++;
+        }
+        return res;
+    }
+}

--- a/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/utils/TypeAclitem.java
+++ b/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/utils/TypeAclitem.java
@@ -1,0 +1,9 @@
+package com.gigaspaces.sql.aggregatornode.netty.utils;
+
+public class TypeAclitem extends PgType {
+    public static final PgType INSTANCE = new TypeAclitem();
+
+    public TypeAclitem() {
+        super(1033, "aclitem", 12, 1034, 0);
+    }
+}

--- a/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/utils/TypeAnyarray.java
+++ b/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/utils/TypeAnyarray.java
@@ -1,0 +1,9 @@
+package com.gigaspaces.sql.aggregatornode.netty.utils;
+
+public class TypeAnyarray extends PgTypeArray<Object> {
+    public static final PgType INSTANCE = new TypeAnyarray();
+
+    public TypeAnyarray() {
+        super(2277, "anyarray", -1, 0, TypeUtils.PG_TYPE_ANY.id);
+    }
+}

--- a/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/utils/TypeFloat4.java
+++ b/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/utils/TypeFloat4.java
@@ -8,7 +8,7 @@ public class TypeFloat4 extends PgType {
     public static final PgType INSTANCE = new TypeFloat4();
 
     public TypeFloat4() {
-        super(700, "float8", 4, 1021, 0);
+        super(700, "float4", 4, 1021, 0);
     }
 
     @Override

--- a/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/utils/TypeNodeTree.java
+++ b/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/utils/TypeNodeTree.java
@@ -4,34 +4,32 @@ import com.gigaspaces.sql.aggregatornode.netty.exception.ProtocolException;
 import com.gigaspaces.sql.aggregatornode.netty.query.Session;
 import io.netty.buffer.ByteBuf;
 
-// TODO implement type encoder/decoder
-public class TypeRegproc extends PgType {
-    public static final PgType INSTANCE = new TypeRegproc();
+public class TypeNodeTree extends PgType {
+    public static final PgType INSTANCE = new TypeNodeTree();
 
-    public TypeRegproc() {
-        super(24, "regproc", 4, 1008, 0);
+    public TypeNodeTree() {
+        super(194, "pg_node_tree", -1, 0, 0);
     }
 
     @Override
     protected void asTextInternal(Session session, ByteBuf dst, Object value) throws ProtocolException {
-        TypeUtils.checkType(value, Integer.class);
+        TypeUtils.checkType(value, String.class);
         TypeUtils.writeText(session, dst, value.toString());
     }
 
     @Override
     protected <T> T fromTextInternal(Session session, ByteBuf src) {
-        return (T) Integer.valueOf(TypeUtils.readText(session, src));
+        return (T) TypeUtils.readText(session, src);
     }
 
     @Override
     protected void asBinaryInternal(Session session, ByteBuf dst, Object value) throws ProtocolException {
-        TypeUtils.checkType(value, Integer.class);
-        dst.writeInt(4).writeInt((Integer) value);
+        TypeUtils.checkType(value, String.class);
+        TypeUtils.writeText(session, dst, value.toString());
     }
 
     @Override
-    protected <T> T fromBinaryInternal(Session session, ByteBuf src) throws ProtocolException {
-        TypeUtils.checkLen(src, 4);
-        return (T) Integer.valueOf(src.readInt());
+    protected <T> T fromBinaryInternal(Session session, ByteBuf src) {
+        return (T) TypeUtils.readText(session, src);
     }
 }

--- a/xap-extensions/xap-aggregator-node/src/test/java/com/gigaspaces/sql/aggregatornode/netty/server/ServerBeanTest.java
+++ b/xap-extensions/xap-aggregator-node/src/test/java/com/gigaspaces/sql/aggregatornode/netty/server/ServerBeanTest.java
@@ -72,9 +72,8 @@ class ServerBeanTest {
         }
     }
 
-    // TODO return test over extended query protocol after parameters support by SqlValidator implemented
     @ParameterizedTest
-    @ValueSource(booleans = {true/*, false */})
+    @ValueSource(booleans = {true, false})
     void testParametrized(boolean simple) throws Exception {
         try (Connection conn = connect(simple)) {
             final String qry = String.format("SELECT first_name, last_name, email, age FROM \"%s\" as T where T.last_name = ? OR T.first_name = ?", MyPojo.class.getName());
@@ -83,6 +82,68 @@ class ServerBeanTest {
             statement.setString(2, "Adam");
 
             assertTrue(statement.execute());
+
+            // TODO since runtime doesn't support dynamic parameters at now there is no results checking
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testAmTable(boolean simple) throws Exception {
+        try (Connection conn = connect(simple)) {
+            final String qry = "SELECT * from pg_catalog.pg_am where 1 = 1";
+            final PreparedStatement statement = conn.prepareStatement(qry);
+            assertTrue(statement.execute());
+            ResultSet res = statement.getResultSet();
+            DumpUtils.dump(res);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testTypeTable(boolean simple) throws Exception {
+        try (Connection conn = connect(simple)) {
+            final String qry = "SELECT * from pg_catalog.pg_type where 1 = 1";
+            final PreparedStatement statement = conn.prepareStatement(qry);
+            assertTrue(statement.execute());
+            ResultSet res = statement.getResultSet();
+            DumpUtils.dump(res);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testAttributeTable(boolean simple) throws Exception {
+        try (Connection conn = connect(simple)) {
+            final String qry = "SELECT * from pg_catalog.pg_attribute where 1 = 1";
+            final PreparedStatement statement = conn.prepareStatement(qry);
+            assertTrue(statement.execute());
+            ResultSet res = statement.getResultSet();
+            DumpUtils.dump(res);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testNamespaceTable(boolean simple) throws Exception {
+        try (Connection conn = connect(simple)) {
+            final String qry = "SELECT * from pg_catalog.pg_namespace where 1 = 1";
+            final PreparedStatement statement = conn.prepareStatement(qry);
+            assertTrue(statement.execute());
+            ResultSet res = statement.getResultSet();
+            DumpUtils.dump(res);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testClassTable(boolean simple) throws Exception {
+        try (Connection conn = connect(simple)) {
+            final String qry = "SELECT * from pg_catalog.pg_class where 1 = 1";
+            final PreparedStatement statement = conn.prepareStatement(qry);
+            assertTrue(statement.execute());
+            ResultSet res = statement.getResultSet();
+            DumpUtils.dump(res);
         }
     }
 

--- a/xap-extensions/xap-jdbc/pom.xml
+++ b/xap-extensions/xap-jdbc/pom.xml
@@ -14,7 +14,6 @@
     </parent>
     <artifactId>xap-jdbc</artifactId>
 
-
     <dependencies>
         <dependency>
             <groupId>com.github.jsqlparser</groupId>
@@ -128,11 +127,18 @@
                             <includes>
                                 <include>**/Parser.jj</include>
                             </includes>
-                            <lookAhead>2</lookAhead>
+                            <lookAhead>1</lookAhead>
                             <isStatic>false</isStatic>
                         </configuration>
                     </execution>
                 </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>net.java.dev.javacc</groupId>
+                        <artifactId>javacc</artifactId>
+                        <version>4.0</version>
+                    </dependency>
+                </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/xap-extensions/xap-jdbc/src/main/codegen/config.fmpp
+++ b/xap-extensions/xap-jdbc/src/main/codegen/config.fmpp
@@ -391,6 +391,7 @@ data: {
     # Return type of method implementation should be "SqlNode".
     # Example: ParseJsonLiteral().
     literalParserMethods: [
+      "PgDynamicParam()"
     ]
 
     # List of methods for parsing custom data types.
@@ -423,10 +424,13 @@ data: {
 
     # Binary operators tokens
     binaryOperatorsTokens: [
+      "< INFIX_CAST: \"::\" >"
+      "< PG_DYNAMIC_PARAM: \"$\" ([\"1\"-\"9\"])+ >"
     ]
 
     # Binary operators initialization
     extraBinaryExpressions: [
+      "InfixCast"
     ]
 
     # List of files in @includes directory that have parser method

--- a/xap-extensions/xap-jdbc/src/main/codegen/includes/parserImpls.ftl
+++ b/xap-extensions/xap-jdbc/src/main/codegen/includes/parserImpls.ftl
@@ -84,3 +84,32 @@ SqlSetOption SqlSetOptionAlt() :
         }
     )
 }
+
+void InfixCast(List<Object> list, ExprContext exprContext, Span s) :
+{
+    final SqlDataTypeSpec dt;
+}
+{
+    <INFIX_CAST> {
+        checkNonQueryExpression(exprContext);
+    }
+    dt = DataType() {
+        list.add(
+            new SqlParserUtil.ToTreeListItem(SqlLibraryOperators.INFIX_CAST,
+                s.pos()));
+        list.add(dt);
+    }
+}
+
+/**
+ * Parses a dynamic parameter marker.
+ */
+SqlDynamicParam PgDynamicParam() :
+{
+}
+{
+    <PG_DYNAMIC_PARAM> {
+        int ordinal = Integer.parseInt(token.image.substring(1)) - 1;
+        return new SqlDynamicParam(ordinal, getPos());
+    }
+}

--- a/xap-extensions/xap-jdbc/src/main/java/com/gigaspaces/jdbc/calcite/GSNamedSchema.java
+++ b/xap-extensions/xap-jdbc/src/main/java/com/gigaspaces/jdbc/calcite/GSNamedSchema.java
@@ -1,0 +1,8 @@
+package com.gigaspaces.jdbc.calcite;
+
+import org.apache.calcite.schema.Schema;
+
+public interface GSNamedSchema extends Schema {
+    String getName();
+    boolean isDefault();
+}

--- a/xap-extensions/xap-jdbc/src/main/java/com/gigaspaces/jdbc/calcite/GSTable.java
+++ b/xap-extensions/xap-jdbc/src/main/java/com/gigaspaces/jdbc/calcite/GSTable.java
@@ -1,54 +1,11 @@
 package com.gigaspaces.jdbc.calcite;
 
-import com.gigaspaces.internal.metadata.ITypeDesc;
-import com.gigaspaces.internal.metadata.PropertyInfo;
-import org.apache.calcite.rel.type.RelDataType;
-import org.apache.calcite.rel.type.RelDataTypeFactory;
-import org.apache.calcite.schema.impl.AbstractTable;
-import org.apache.calcite.sql.type.SqlTypeName;
+import com.gigaspaces.jdbc.model.table.TableContainer;
+import com.j_spaces.core.IJSpace;
+import org.apache.calcite.schema.Table;
+import org.apache.calcite.schema.Wrapper;
 
-public class GSTable extends AbstractTable {
-
-    private final ITypeDesc typeDesc;
-    private final String name;
-
-    public GSTable(String name, ITypeDesc typeDesc) {
-        this.name = name;
-        this.typeDesc = typeDesc;
-    }
-
-    @Override
-    public RelDataType getRowType(RelDataTypeFactory typeFactory) {
-        RelDataTypeFactory.Builder builder = new RelDataTypeFactory.Builder(typeFactory);
-        for (PropertyInfo property : typeDesc.getProperties()) {
-            builder.add(
-                property.getName(),
-                mapToSqlType(property.getType())
-            );
-        }
-        return builder.build();
-    }
-
-    private static SqlTypeName mapToSqlType(Class<?> clazz) {
-        if (clazz == Integer.class) {
-            return SqlTypeName.INTEGER;
-        } else if (clazz == Long.class) {
-            return SqlTypeName.BIGINT;
-        } else if (clazz == String.class) {
-            return SqlTypeName.VARCHAR;
-        } else if (clazz == java.util.Date.class) {
-            return SqlTypeName.DATE;
-        } else if (clazz == java.sql.Time.class) {
-            return SqlTypeName.TIME;
-        } else if (clazz == java.sql.Timestamp.class) {
-            return SqlTypeName.TIMESTAMP;
-        }
-
-
-        throw new UnsupportedOperationException("Unsupported type: " + clazz);
-    }
-
-    public String getName() {
-        return name;
-    }
+public interface GSTable extends Table, Wrapper {
+    String getName();
+    TableContainer createTableContainer(IJSpace space);
 }

--- a/xap-extensions/xap-jdbc/src/main/java/com/gigaspaces/jdbc/calcite/GSTableImpl.java
+++ b/xap-extensions/xap-jdbc/src/main/java/com/gigaspaces/jdbc/calcite/GSTableImpl.java
@@ -1,0 +1,63 @@
+package com.gigaspaces.jdbc.calcite;
+
+import com.gigaspaces.internal.metadata.ITypeDesc;
+import com.gigaspaces.internal.metadata.PropertyInfo;
+import com.gigaspaces.jdbc.model.table.ConcreteTableContainer;
+import com.gigaspaces.jdbc.model.table.TableContainer;
+import com.j_spaces.core.IJSpace;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.schema.impl.AbstractTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+
+public class GSTableImpl extends AbstractTable implements GSTable {
+
+    private final ITypeDesc typeDesc;
+    private final String name;
+
+    public GSTableImpl(String name, ITypeDesc typeDesc) {
+        this.name = name;
+        this.typeDesc = typeDesc;
+    }
+
+    @Override
+    public RelDataType getRowType(RelDataTypeFactory typeFactory) {
+        RelDataTypeFactory.Builder builder = new RelDataTypeFactory.Builder(typeFactory);
+        for (PropertyInfo property : typeDesc.getProperties()) {
+            builder.add(
+                property.getName(),
+                mapToSqlType(property.getType())
+            );
+        }
+        return builder.build();
+    }
+
+    private static SqlTypeName mapToSqlType(Class<?> clazz) {
+        if (clazz == Integer.class) {
+            return SqlTypeName.INTEGER;
+        } else if (clazz == Long.class) {
+            return SqlTypeName.BIGINT;
+        } else if (clazz == String.class) {
+            return SqlTypeName.VARCHAR;
+        } else if (clazz == java.util.Date.class) {
+            return SqlTypeName.DATE;
+        } else if (clazz == java.sql.Time.class) {
+            return SqlTypeName.TIME;
+        } else if (clazz == java.sql.Timestamp.class) {
+            return SqlTypeName.TIMESTAMP;
+        }
+
+
+        throw new UnsupportedOperationException("Unsupported type: " + clazz);
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public TableContainer createTableContainer(IJSpace space) {
+        return new ConcreteTableContainer(getName(), null, space);
+    }
+}

--- a/xap-extensions/xap-jdbc/src/main/java/com/gigaspaces/jdbc/calcite/GSTypeResolver.java
+++ b/xap-extensions/xap-jdbc/src/main/java/com/gigaspaces/jdbc/calcite/GSTypeResolver.java
@@ -1,0 +1,10 @@
+package com.gigaspaces.jdbc.calcite;
+
+import org.apache.calcite.rel.type.RelProtoDataType;
+
+import java.util.Set;
+
+public interface GSTypeResolver {
+    Set<String> registeredTypeNames();
+    RelProtoDataType resolveType(String name);
+}

--- a/xap-extensions/xap-jdbc/src/main/java/com/gigaspaces/jdbc/calcite/RelNodePhysicalPlanHandler.java
+++ b/xap-extensions/xap-jdbc/src/main/java/com/gigaspaces/jdbc/calcite/RelNodePhysicalPlanHandler.java
@@ -2,9 +2,6 @@ package com.gigaspaces.jdbc.calcite;
 
 import com.gigaspaces.jdbc.PhysicalPlanHandler;
 import com.gigaspaces.jdbc.QueryExecutor;
-import com.gigaspaces.jdbc.calcite.schema.GSSchemaTable;
-import com.gigaspaces.jdbc.model.table.ConcreteTableContainer;
-import com.gigaspaces.jdbc.model.table.SchemaTableContainer;
 import com.gigaspaces.jdbc.model.table.TableContainer;
 import com.j_spaces.jdbc.builder.QueryTemplatePacket;
 import org.apache.calcite.plan.RelOptTable;
@@ -36,7 +33,6 @@ public class RelNodePhysicalPlanHandler implements PhysicalPlanHandler<GSRelNode
                 // TODO: Extract type and column info, put to stack.
                 RelOptTable relOptTable = scan.getTable();
                 Object table = relOptTable.unwrap(GSTable.class);
-                if (table == null) table = relOptTable.unwrap(GSSchemaTable.class);
                 stack.push(table);
                 return scan;
             }
@@ -49,10 +45,8 @@ public class RelNodePhysicalPlanHandler implements PhysicalPlanHandler<GSRelNode
                     GSCalc calc = (GSCalc) other;
                     Object pop = stack.pop();
                     TableContainer tableContainer;
-                    if (pop instanceof GSSchemaTable) {
-                        tableContainer = new SchemaTableContainer(((GSSchemaTable) pop), queryExecutor.getSpace());
-                    } else if (pop instanceof GSTable) {
-                        tableContainer = new ConcreteTableContainer(((GSTable) pop).getName(), null, queryExecutor.getSpace());
+                    if (pop instanceof GSTable) {
+                        tableContainer = ((GSTable) pop).createTableContainer(queryExecutor.getSpace());
                     } else {
                         throw new UnsupportedOperationException("Got unsupported table type: " + pop);
                     }
@@ -81,6 +75,7 @@ public class RelNodePhysicalPlanHandler implements PhysicalPlanHandler<GSRelNode
                 return res;
             }
         });
+
         return queryExecutor;
     }
 }


### PR DESCRIPTION
Some glue code was added to register additional schemas in calcite planner
PG system catalog tables were created, there are only tables that required by ODBC/JDBC drivers, some columns were excluded (PG specific metadata, which isn't necessary for drivers)
PG infix cast syntax support is added (`literal::type`)
PG parameter syntax support is added (`SELECT * FROM table WHERE id = $1`)
Simple metadata generator is implemented to fill in `pg_attribute` and `pg_class` tables, at now it guaranties oid uniques and consistency across a single session, there are no oid consistence guaranties between different sessions