### PR TITLE
Jdbc compatibility

### DIFF
--- a/xap-extensions/xap-aggregator-node/pom.xml
+++ b/xap-extensions/xap-aggregator-node/pom.xml
@@ -16,7 +16,19 @@
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
         <xap.dep.scope>provided</xap.dep.scope>
+        <postgresql.groupId>org.postgresql</postgresql.groupId>
+        <postgresql.version>42.2.20</postgresql.version>
     </properties>
+
+    <profiles>
+        <profile>
+            <id>postgresql-old-driver</id>
+            <properties>
+                <postgresql.groupId>postgresql</postgresql.groupId>
+                <postgresql.version>8.2-507.jdbc4</postgresql.version>
+            </properties>
+        </profile>
+    </profiles>
 
     <dependencyManagement>
         <dependencies>
@@ -100,9 +112,9 @@
         </dependency>
 
         <dependency>
-            <groupId>org.postgresql</groupId>
+            <groupId>${postgresql.groupId}</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.2.20</version>
+            <version>${postgresql.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/query/DmlPortal.java
+++ b/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/query/DmlPortal.java
@@ -39,7 +39,7 @@ class DmlPortal<T> implements Portal<T> {
     @Override
     public String tag() {
         if (command == PortalCommand.SET)
-            return String.format("%s %d", command.tag(), processed);
+            return command.tag();
         return String.format("%s 0 %d", command.tag(), processed);
     }
 

--- a/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/query/MockStatement.java
+++ b/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/query/MockStatement.java
@@ -1,0 +1,19 @@
+package com.gigaspaces.sql.aggregatornode.netty.query;
+
+import com.gigaspaces.exception.lrmi.ProtocolException;
+
+import java.util.Iterator;
+
+public class MockStatement<T> extends StatementImpl implements ThrowingSupplier<Iterator<T>, ProtocolException> {
+    private final ThrowingSupplier<Iterator<T>, ProtocolException> op;
+
+    public MockStatement(QueryProviderImpl queryProvider, String name, StatementDescription description, ThrowingSupplier<Iterator<T>, ProtocolException> op) {
+        super(queryProvider, name, null, null, description);
+        this.op = op;
+    }
+
+    @Override
+    public Iterator<T> apply() throws ProtocolException {
+        return op.apply();
+    }
+}

--- a/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/query/Session.java
+++ b/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/query/Session.java
@@ -7,12 +7,15 @@ import com.j_spaces.core.client.SpaceFinder;
 
 import java.io.Closeable;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 import java.util.TimeZone;
 
 import static com.gigaspaces.sql.aggregatornode.netty.utils.Constants.*;
 
 public class Session implements Closeable {
     private Charset charset = DEFAULT_CHARSET;
+    private String charsetName = DEFAULT_CHARSET.name();
     private String dateStyle = DEFAULT_DATE_STYLE;
     private TimeZone timeZone = DEFAULT_TIME_ZONE;
     private String username = "";
@@ -24,6 +27,22 @@ public class Session implements Closeable {
         if (dateTimeUtils == null)
             dateTimeUtils = new DateTimeUtils(this);
         return dateTimeUtils;
+    }
+
+    public void setCharsetByName(String charsetName) {
+        switch (charsetName.toUpperCase(Locale.ROOT)) {
+            case "UNICODE":
+            case "UTF8":
+                charset = StandardCharsets.UTF_8;
+                break;
+            default:
+                charset = Charset.forName(charsetName);
+        }
+        this.charsetName = charsetName;
+    }
+
+    public String getCharsetName() {
+        return charsetName;
     }
 
     public Charset getCharset() {

--- a/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/query/StatementDescription.java
+++ b/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/query/StatementDescription.java
@@ -1,5 +1,7 @@
 package com.gigaspaces.sql.aggregatornode.netty.query;
 
+import java.util.Arrays;
+
 public class StatementDescription {
     public static final StatementDescription EMPTY =
             new StatementDescription(ParametersDescription.EMPTY, RowDescription.EMPTY);
@@ -10,6 +12,10 @@ public class StatementDescription {
     public StatementDescription(ParametersDescription parametersDescription, RowDescription rowDescription) {
         this.parametersDescription = parametersDescription;
         this.rowDescription = rowDescription;
+    }
+
+    public StatementDescription(ColumnDescription... columns) {
+        this(ParametersDescription.EMPTY, new RowDescription(Arrays.asList(columns)));
     }
 
     public ParametersDescription getParametersDescription() {

--- a/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/server/MessageProcessor.java
+++ b/xap-extensions/xap-aggregator-node/src/main/java/com/gigaspaces/sql/aggregatornode/netty/server/MessageProcessor.java
@@ -14,7 +14,6 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.util.ReferenceCountUtil;
 import org.slf4j.Logger;
 
-import java.nio.charset.Charset;
 import java.security.SecureRandom;
 import java.util.List;
 import java.util.TimeZone;
@@ -386,7 +385,7 @@ public class MessageProcessor extends ChannelInboundHandlerAdapter {
         switch (version) {
             case PROTOCOL_3_0:
                 initRead = true;
-                Charset newCharset = null;
+                String charsetName = null;
                 while (msg.getByte(msg.readerIndex()) > 0) {
                     String key = readString(msg);
                     String value = readString(msg);
@@ -407,7 +406,7 @@ public class MessageProcessor extends ChannelInboundHandlerAdapter {
                                     && value.charAt(length - 1) == '\'') {
                                 value = value.substring(1, length - 1);
                             }
-                            newCharset = Charset.forName(value);
+                            charsetName = value;
                             break;
                         }
                         case "DateStyle": {
@@ -430,8 +429,8 @@ public class MessageProcessor extends ChannelInboundHandlerAdapter {
                     }
                 }
 
-                if (newCharset != null)
-                    session.setCharset(newCharset);
+                if (charsetName != null)
+                    session.setCharsetByName(charsetName);
 
                 // request clear text password
                 if (authProvider == AuthenticationProvider.NO_OP_PROVIDER)
@@ -462,7 +461,7 @@ public class MessageProcessor extends ChannelInboundHandlerAdapter {
     private void onAuthenticationOK(ChannelHandlerContext ctx) throws ProtocolException {
         ByteBuf buf = ctx.alloc().ioBuffer();
         writeAuthenticationOK(buf);
-        writeParameterStatus(buf, "client_encoding", session.getCharset().name());
+        writeParameterStatus(buf, "client_encoding", session.getCharsetName());
         writeParameterStatus(buf, "DateStyle", session.getDateStyle());
         writeParameterStatus(buf, "is_superuser", "off");
         writeParameterStatus(buf, "server_encoding", "SQL_ASCII");

--- a/xap-extensions/xap-aggregator-node/src/test/java/com/gigaspaces/sql/aggregatornode/netty/server/AbstractServerTest.java
+++ b/xap-extensions/xap-aggregator-node/src/test/java/com/gigaspaces/sql/aggregatornode/netty/server/AbstractServerTest.java
@@ -35,8 +35,6 @@ public class AbstractServerTest {
             url += "&preferQueryMode=simple";
 
         final Connection conn = DriverManager.getConnection(url);
-        assertFalse(conn.isClosed());
-        assertTrue(conn.isValid(1000));
         return conn;
     }
 }

--- a/xap-extensions/xap-aggregator-node/src/test/java/com/gigaspaces/sql/aggregatornode/netty/server/ServerBeanTest.java
+++ b/xap-extensions/xap-aggregator-node/src/test/java/com/gigaspaces/sql/aggregatornode/netty/server/ServerBeanTest.java
@@ -42,7 +42,6 @@ class ServerBeanTest extends AbstractServerTest{
     void testConnection(boolean simple) throws Exception {
         try (Connection conn = connect(simple)) {
             assertFalse(conn.isClosed());
-            assertTrue(conn.isValid(1000));
         }
     }
 
@@ -51,7 +50,7 @@ class ServerBeanTest extends AbstractServerTest{
     void testSet(boolean simple) throws Exception {
         try (Connection conn = connect(simple)) {
             final Statement statement = conn.createStatement();
-            assertEquals(1, statement.executeUpdate("SET DateStyle = 'ISO'"));
+            assertFalse(statement.execute("SET DateStyle = 'ISO'")); // false mean the statement doesn't return a result set
         }
     }
 
@@ -129,7 +128,7 @@ class ServerBeanTest extends AbstractServerTest{
 
             qry = "SET TimeZone='GMT-1'"; // PG uses posix timezones which are negated
             try (PreparedStatement statement = conn.prepareStatement(qry)) {
-                assertEquals(1, statement.executeUpdate());
+                statement.execute();
             }
 
             qry = String.format("SELECT \"timestamp\" FROM \"%s\" where first_name = 'Adam'", MyPojo.class.getName());
@@ -170,7 +169,7 @@ class ServerBeanTest extends AbstractServerTest{
             String expected = "" +
 "| oid  | typname           | typnamespace | typowner | typlen | typbyval | typtype | typisdefined | typdelim | typrelid | typelem | typinput | typoutput | typreceive | typsend | typanalyze | typalign | typstorage | typnotnull | typbasetype | typtypmod | typndims | typdefaultbin | typdefault |\n" +
 "| ---- | ----------------- | ------------ | -------- | ------ | -------- | ------- | ------------ | -------- | -------- | ------- | -------- | --------- | ---------- | ------- | ---------- | -------- | ---------- | ---------- | ----------- | --------- | -------- | ------------- | ---------- |\n" +
-"| 1028 | oid[]         | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 26      | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n" +
+"| 1028 | oid[]             | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 26      | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n" +
 "| 16   | bool              | -1000        | 0        | 1      | null     | b       | true         | ,        | 0        | 0       | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 0        | null          | null       |\n" +
 "| 17   | bytea             | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 0       | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 0        | null          | null       |\n" +
 "| 1042 | bpchar            | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 0       | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 0        | null          | null       |\n" +
@@ -182,16 +181,16 @@ class ServerBeanTest extends AbstractServerTest{
 "| 22   | int2vector        | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 21      | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n" +
 "| 23   | int4              | -1000        | 0        | 4      | null     | b       | true         | ,        | 0        | 0       | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 0        | null          | null       |\n" +
 "| 24   | regproc           | -1000        | 0        | 4      | null     | b       | true         | ,        | 0        | 0       | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 0        | null          | null       |\n" +
-"| 2201 | refcursor[]   | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 1790    | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n" +
+"| 2201 | refcursor[]       | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 1790    | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n" +
 "| 25   | text              | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 0       | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 0        | null          | null       |\n" +
 "| 26   | oid               | -1000        | 0        | 4      | null     | b       | true         | ,        | 0        | 0       | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 0        | null          | null       |\n" +
-"| 1182 | date[]        | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 1082    | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n" +
+"| 1182 | date[]            | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 1082    | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n" +
 "| 30   | oidvector         | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 26      | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n" +
-"| 1183 | time[]        | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 1083    | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n" +
+"| 1183 | time[]            | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 1083    | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n" +
 "| 1184 | timestamptz       | -1000        | 0        | 8      | null     | b       | true         | ,        | 0        | 0       | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 0        | null          | null       |\n" +
-"| 1185 | timestamptz[] | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 1184    | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n" +
+"| 1185 | timestamptz[]     | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 1184    | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n" +
 "| 1186 | interval          | -1000        | 0        | 16     | null     | b       | true         | ,        | 0        | 0       | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 0        | null          | null       |\n" +
-"| 1187 | interval[]    | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 1186    | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n" +
+"| 1187 | interval[]        | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 1186    | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n" +
 "| 1700 | numeric           | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 0       | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 0        | null          | null       |\n" +
 "| 1082 | date              | -1000        | 0        | 4      | null     | b       | true         | ,        | 0        | 0       | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 0        | null          | null       |\n" +
 "| 1083 | time              | -1000        | 0        | 8      | null     | b       | true         | ,        | 0        | 0       | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 0        | null          | null       |\n" +
@@ -199,27 +198,27 @@ class ServerBeanTest extends AbstractServerTest{
 "| 701  | float8            | -1000        | 0        | 8      | null     | b       | true         | ,        | 0        | 0       | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 0        | null          | null       |\n" +
 "| 705  | unknown           | -1000        | 0        | -2     | null     | b       | true         | ,        | 0        | 0       | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 0        | null          | null       |\n" +
 "| 194  | pg_node_tree      | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 0       | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 0        | null          | null       |\n" +
-"| 1231 | numeric[]     | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 1700    | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n" +
+"| 1231 | numeric[]         | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 1700    | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n" +
 "| 1114 | timestamp         | -1000        | 0        | 8      | null     | b       | true         | ,        | 0        | 0       | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 0        | null          | null       |\n" +
-"| 1115 | timestamp[]   | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 1114    | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n" +
+"| 1115 | timestamp[]       | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 1114    | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n" +
 "| 2276 | any               | -1000        | 0        | 4      | null     | b       | true         | ,        | 0        | 0       | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 0        | null          | null       |\n" +
-"| 1000 | bool[]        | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 16      | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n" +
-"| 1001 | bytea[]       | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 17      | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n" +
-"| 1002 | char[]        | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 18      | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n" +
-"| 1003 | name[]        | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 19      | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n" +
-"| 1005 | int2[]        | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 21      | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n" +
-"| 1006 | int2vector[]  | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 22      | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n" +
-"| 1007 | int4[]        | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 23      | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n" +
-"| 1008 | regproc[]     | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 24      | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n" +
-"| 1009 | text[]        | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 25      | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n" +
+"| 1000 | bool[]            | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 16      | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n" +
+"| 1001 | bytea[]           | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 17      | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n" +
+"| 1002 | char[]            | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 18      | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n" +
+"| 1003 | name[]            | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 19      | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n" +
+"| 1005 | int2[]            | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 21      | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n" +
+"| 1006 | int2vector[]      | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 22      | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n" +
+"| 1007 | int4[]            | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 23      | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n" +
+"| 1008 | regproc[]         | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 24      | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n" +
+"| 1009 | text[]            | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 25      | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n" +
 "| 1266 | timetz            | -1000        | 0        | 12     | null     | b       | true         | ,        | 0        | 0       | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 0        | null          | null       |\n" +
-"| 1014 | bpchar[]      | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 1042    | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n" +
-"| 1270 | timetz[]      | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 1266    | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n" +
-"| 1015 | varchar[]     | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 1043    | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n" +
-"| 1016 | int8[]        | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 20      | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n" +
-"| 1021 | float4[]      | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 700     | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n" +
+"| 1014 | bpchar[]          | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 1042    | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n" +
+"| 1270 | timetz[]          | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 1266    | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n" +
+"| 1015 | varchar[]         | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 1043    | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n" +
+"| 1016 | int8[]            | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 20      | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n" +
+"| 1021 | float4[]          | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 700     | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n" +
 "| 1790 | refcursor         | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 0       | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 0        | null          | null       |\n" +
-"| 1022 | float8[]      | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 701     | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n";
+"| 1022 | float8[]          | -1000        | 0        | -1     | null     | b       | true         | ,        | 0        | 701     | 0        | 0         | 0          | 0       | 0          | c        | p          | false      | 0           | -1        | 1        | null          | null       |\n";
             DumpUtils.checkResult(res, expected);
         }
     }
@@ -319,10 +318,8 @@ class ServerBeanTest extends AbstractServerTest{
 "| Adler      | Aa        | Adler@msn.com | 20  |\n" +
 "| Adam       | Bb        | Adam@msn.com  | 30  |\n";
             DumpUtils.checkResult(res, expected);
-            statement.getMoreResults();
-            int updateCount = statement.getUpdateCount();
-            assertEquals(1, updateCount);
-            statement.getMoreResults();
+            assertFalse(statement.getMoreResults());
+            assertTrue(statement.getMoreResults());
             res = statement.getResultSet();
             expected = "" +
 "| transaction_isolation |\n" +


### PR DESCRIPTION
There were 3 causes because of which tests failed with old driver version:

1.  old driver couldn't recognize a charset name what it get from a server - different names used then and now
2.  old driver doesn't expect a modification counter in SET operation tag while current version does (at now it's up to a server to send it or not)
3. at each test start a driver connection was validated, the validation method isn't implemented in old driver

I also added a maven profile that allows runnung all test scenarios against old driver version