### PR TITLE
PRX 227 : Support CEF log messages

### DIFF
--- a/xap-core/xap-common/src/main/java/com/gigaspaces/logger/GSLogConfigLoader.java
+++ b/xap-core/xap-common/src/main/java/com/gigaspaces/logger/GSLogConfigLoader.java
@@ -127,7 +127,6 @@ public class GSLogConfigLoader {
      * @return GSLogConfigLoader instance
      */
     public static synchronized GSLogConfigLoader getLoader(String fileHanderPattern) {
-        // TODO : extract it
         RollingFileHandlerConfigurer.setServiceProperty(fileHanderPattern, false /*override if exists*/);
         _filePatternName = fileHanderPattern;
         return getLoader();

--- a/xap-core/xap-common/src/main/java/com/gigaspaces/logger/GSLogConfigLoader.java
+++ b/xap-core/xap-common/src/main/java/com/gigaspaces/logger/GSLogConfigLoader.java
@@ -127,6 +127,7 @@ public class GSLogConfigLoader {
      * @return GSLogConfigLoader instance
      */
     public static synchronized GSLogConfigLoader getLoader(String fileHanderPattern) {
+        // TODO : extract it
         RollingFileHandlerConfigurer.setServiceProperty(fileHanderPattern, false /*override if exists*/);
         _filePatternName = fileHanderPattern;
         return getLoader();

--- a/xap-core/xap-common/src/main/java/com/gigaspaces/logger/GSSimpleFormatter.java
+++ b/xap-core/xap-common/src/main/java/com/gigaspaces/logger/GSSimpleFormatter.java
@@ -184,7 +184,7 @@ public class GSSimpleFormatter extends Formatter {
         }
 
         if (patternIds[DEVICE_PRODUCT]) {
-            _args[DEVICE_PRODUCT] = RollingFileHandler.overrides.getProperty(RollingFileHandler.SERVICE_PROP);
+            _args[DEVICE_PRODUCT] = findContext();
         }
 
         if (patternIds[DEVICE_VERSION]) {

--- a/xap-core/xap-common/src/main/java/com/gigaspaces/logger/GSSimpleFormatter.java
+++ b/xap-core/xap-common/src/main/java/com/gigaspaces/logger/GSSimpleFormatter.java
@@ -18,6 +18,7 @@
 package com.gigaspaces.logger;
 
 import com.gigaspaces.internal.version.PlatformVersion;
+import com.gigaspaces.logger.cef.ESCAPE_SYMBOLS;
 import com.gigaspaces.lrmi.LRMIInvocationContext;
 
 import com.gigaspaces.start.SystemInfo;
@@ -31,6 +32,9 @@ import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.Date;
 import java.util.logging.*;
+
+import static com.gigaspaces.logger.LogUtils.toSeverity;
+import static com.gigaspaces.logger.cef.ESCAPE_SYMBOLS.quoteSpaces;
 
 /**
  * Print a brief summary of the LogRecord in a human readable messageFormat. This class is a
@@ -55,14 +59,10 @@ public class GSSimpleFormatter extends Formatter {
     final static int LRMI_INVOCATION_SHORT_CONTEXT = 9;
     final static int LRMI_INVOCATION_LONG_CONTEXT = 10;
     final static int HOST = 11;
-    final static int CEF_VERSION = 12;
-    final static int DEVICE_VENDOR = 13;
-    final static int DEVICE_PRODUCT = 14;
-    final static int DEVICE_VERSION = 15;
-    final static int SIGNATURE_ID = 16;
-    final static int NAME = 17;
-    final static int SEVERITY = 18;
-    final static int EXTENSION = 19;
+    final static int DEVICE_PRODUCT = 12;
+    final static int DEVICE_VERSION = 13;
+    final static int SEVERITY = 14;
+    final static int EXTENSION = 15;
     final static int lastIndex = EXTENSION + 1;
 
     private final static String defaultPattern = "{0,date,yyyy-MM-dd HH:mm:ss,SSS} {6} {3} [{4}] - {5}";
@@ -179,39 +179,16 @@ public class GSSimpleFormatter extends Formatter {
         if (patternIds[LRMI_INVOCATION_LONG_CONTEXT])
             _args[LRMI_INVOCATION_LONG_CONTEXT] = LRMIInvocationContext.getContextMethodLongDisplayString();
 
-        // TODO : add additional arguments for CEF if needed
-        // Jan 18 11:07:53 host CEF:Version|Device Vendor|Device Product|Device Version|SignatureID|Name|Severity|Extension
-        // CEF:0|security|threatmanager|1.0|100|detected a \\| in message|10|src=10.0.0.1 act=blocked a \\= and \\ dst=1.1.1.1 fileName=C:\\Program Files\\test.txt port=test
-
         if (patternIds[HOST]) {
             _args[HOST] = SystemInfo.singleton().network().getHostId();
         }
 
-        if (patternIds[CEF_VERSION]) {
-            _args[CEF_VERSION] = "0";
-        }
-
-        if (patternIds[DEVICE_VENDOR]) { // operator|agent|manager|lookup|container
-            // gsa|gsm|gsc
-            _args[DEVICE_VENDOR] = "gigaspaces";//RollingFileHandler.overrides.getProperty(RollingFileHandler.SERVICE_PROP);
-        }
-
         if (patternIds[DEVICE_PRODUCT]) {
-//            _args[DEVICE_PRODUCT] = findContext();
             _args[DEVICE_PRODUCT] = RollingFileHandler.overrides.getProperty(RollingFileHandler.SERVICE_PROP);
-//            _args[DEVICE_PRODUCT] = record.getLoggerName();
         }
 
         if (patternIds[DEVICE_VERSION]) {
             _args[DEVICE_VERSION] = PlatformVersion.getVersion();
-        }
-
-        if (patternIds[SIGNATURE_ID]) {
-            _args[SIGNATURE_ID] = "0";
-        }
-
-        if (patternIds[NAME]) {
-            _args[NAME] = "Legacy Message";
         }
 
         if (patternIds[SEVERITY]) {
@@ -219,59 +196,12 @@ public class GSSimpleFormatter extends Formatter {
         }
 
         if (patternIds[EXTENSION]) {
-//            Extension = should be in key-value format, with the following keys
-//                    method={class name}.{method name}
-//                    context={context} (if not used in the header fields)
-//                    thread={thread id}
-//                    msg={message}
-//                    LRMI={LRMI long invocation context}
             String ext = " method=" + record.getSourceClassName() + "." + record.getSourceMethodName() + " " +
                     "thread=" + record.getThreadID() + " " +
                     "msg=" + quoteSpaces(formatMessage(record)) + " " +
                     "LRMI=" + quoteSpaces(LRMIInvocationContext.getContextMethodLongDisplayString()) + " ";
-            _args[EXTENSION] = toCEFEncoding(ext);
+            _args[EXTENSION] = new String(ext.getBytes() , StandardCharsets.UTF_8);
         }
-    }
-
-    private static String quoteSpaces(String value) {
-        value = value.replace("\n","\\n");
-        return "\""+value.replace("\"", "\\\"")+"\"";
-    }
-
-    private int toSeverity(Level level) {
-        switch (level.intValue()){
-            case 1000:
-                return 9;
-            case 900:
-                return 5;
-            case 800:
-                return 4;
-            case 700:
-                return 3;
-            case 500:
-                return 2;
-            case 400:
-                return 1;
-            default:
-                return 0;
-        }
-    }
-
-    private enum ESCAPE {
-        BLACKSLASH('\\'),
-        PIPE('|'); // TODO : think about '='
-        char ch;
-        ESCAPE(char ch) {
-            this.ch=ch;
-        }
-    }
-
-    private String toCEFEncoding(String log) {
-        // TODO : encode escape symbols
-        for(ESCAPE sign:ESCAPE.values()) {
-            log = log.replace(String.valueOf(sign.ch), "\\");
-        }
-        return new String(log.getBytes(), StandardCharsets.UTF_8);
     }
 
     private String findContext() {
@@ -288,4 +218,5 @@ public class GSSimpleFormatter extends Formatter {
         }
         return "";
     }
+
 }

--- a/xap-core/xap-common/src/main/java/com/gigaspaces/logger/LogUtils.java
+++ b/xap-core/xap-common/src/main/java/com/gigaspaces/logger/LogUtils.java
@@ -1,25 +1,26 @@
 /*
- * 
+ *
  * Copyright 2005 Sun Microsystems, Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * 	http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  */
 package com.gigaspaces.logger;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.StringJoiner;
+import java.util.logging.Level;
 
 import org.slf4j.Logger;
 import org.slf4j.helpers.MessageFormatter;
@@ -27,9 +28,17 @@ import org.slf4j.helpers.MessageFormatter;
 @com.gigaspaces.api.InternalApi
 public class LogUtils {
 
+    public static final int SEVERE = 1000;
+    public static final int WARNING = 900;
+    public static final int INFO = 800;
+    public static final int CONFIG = 700;
+    public static final int FINE = 500;
+    public static final int FINER = 400;
+
     private void foo() {
         LogLevel.INFO.isEnabled(null);
     }
+
     static String getStackTrace(Throwable t) {
         StringWriter sw = new StringWriter();
         PrintWriter pw = new PrintWriter(sw);
@@ -53,13 +62,13 @@ public class LogUtils {
         return message + " [Duration = " + duration + "ms]";
     }
 
-    public static String format(String message, Object ... args) {
+    public static String format(String message, Object... args) {
         if (args == null || args.length == 0)
             return message;
         return MessageFormatter.arrayFormat(message, args, null).getMessage();
     }
 
-    public static String format(Class<?> sourceClass, String sourceMethod, String format, Object ... params) {
+    public static String format(Class<?> sourceClass, String sourceMethod, String format, Object... params) {
         if (format == null || format.isEmpty())
             return sourceClass.getName() + "#" + sourceMethod;
         if (params == null || params.length == 0)
@@ -75,14 +84,14 @@ public class LogUtils {
     }
 
     public static void throwing(Logger logger, Class<?> sourceClass, String sourceMethod, Throwable thrown,
-                                String format, Object ... params) {
+                                String format, Object... params) {
         if (logger.isDebugEnabled()) {
             logger.debug(format(sourceClass, sourceMethod, format, params), thrown);
         }
     }
 
     public static void throwing(LogLevel level, Logger logger, Class<?> sourceClass, String sourceMethod, Throwable thrown,
-                                String format, Object ... params) {
+                                String format, Object... params) {
         if (level.isEnabled(logger)) {
             level.log(logger, format(sourceClass, sourceMethod, format, params), thrown);
         }
@@ -128,7 +137,7 @@ public class LogUtils {
             logger.debug(action("exit", sourceClass.getName(), sourceMethod, args));
     }
 
-    private static String action(String action, String sourceClass, String sourceMethod, Object ... params) {
+    private static String action(String action, String sourceClass, String sourceMethod, Object... params) {
         if (params == null || params.length == 0)
             return sourceClass + "#" + sourceMethod + ": " + action;
         if (params.length == 1)
@@ -138,5 +147,28 @@ public class LogUtils {
             sj.add(String.valueOf(param));
         }
         return sj.toString();
+    }
+
+
+    /*
+     **
+     */
+    public static int toSeverity(Level level) {
+        switch (level.intValue()) {
+            case SEVERE:
+                return 9;
+            case WARNING:
+                return 5;
+            case INFO:
+                return 4;
+            case CONFIG:
+                return 3;
+            case FINE:
+                return 2;
+            case FINER:
+                return 1;
+            default:
+                return 0;
+        }
     }
 }

--- a/xap-core/xap-common/src/main/java/com/gigaspaces/logger/LogUtils.java
+++ b/xap-core/xap-common/src/main/java/com/gigaspaces/logger/LogUtils.java
@@ -149,10 +149,6 @@ public class LogUtils {
         return sj.toString();
     }
 
-
-    /*
-     **
-     */
     public static int toSeverity(Level level) {
         switch (level.intValue()) {
             case SEVERE:

--- a/xap-core/xap-common/src/main/java/com/gigaspaces/logger/cef/ESCAPE_SYMBOLS.java
+++ b/xap-core/xap-common/src/main/java/com/gigaspaces/logger/cef/ESCAPE_SYMBOLS.java
@@ -1,0 +1,31 @@
+package com.gigaspaces.logger.cef;
+
+/*
+ * * List of character leading by backslash :
+ *  \
+ *  |
+ *  =
+ */
+public enum ESCAPE_SYMBOLS {
+    BLACKSLASH('\\'),
+    PIPE('|'),
+    EQUAL_SIGN('=');
+    private final char ch;
+
+    ESCAPE_SYMBOLS(char ch) {
+        this.ch = ch;
+    }
+
+    public char ch() {
+        return ch;
+    }
+
+    public static String quoteSpaces(String value) {
+        for (ESCAPE_SYMBOLS sign : ESCAPE_SYMBOLS.values()) {
+            value = value.replace(String.valueOf(sign.ch()), "\\" + sign.ch());
+        }
+        value = value.replace("\n", "\\n");
+        return "\"" + value.replace("\"", "\\\"") + "\"";
+    }
+
+}

--- a/xap-core/xap-common/src/main/java/com/gigaspaces/start/SystemInfo.java
+++ b/xap-core/xap-common/src/main/java/com/gigaspaces/start/SystemInfo.java
@@ -30,6 +30,7 @@ import net.jini.core.discovery.LookupLocator;
 
 import java.net.MalformedURLException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.StringTokenizer;
 
@@ -200,6 +201,16 @@ public class SystemInfo {
         private static String setSystemProperty(String key, String value) {
             return value != null ? System.setProperty(key, value) : System.clearProperty(key);
         }
+
+        @Override
+        public String toString() {
+            return "XapLookup{" +
+                    "groups='" + groups + '\'' +
+                    ", groupsArray=" + Arrays.toString(groupsArray) +
+                    ", locators='" + locators + '\'' +
+                    ", locatorsArray=" + Arrays.toString(locatorsArray) +
+                    '}';
+        }
     }
 
     public static class XapOperatingSystem {
@@ -217,6 +228,15 @@ public class SystemInfo {
 
         public boolean isWindows() {
             return isWindows;
+        }
+
+        @Override
+        public String toString() {
+            return "XapOperatingSystem{" +
+                    "processId=" + processId +
+                    ", username='" + username + '\'' +
+                    ", isWindows=" + isWindows +
+                    '}';
         }
     }
 
@@ -260,5 +280,17 @@ public class SystemInfo {
         public long timeMillis() {
             return _timeProvider.timeMillis();
         }
+    }
+
+    @Override
+    public String toString() {
+        return "SystemInfo{" +
+                "lookup=" + lookup +
+                ", network=" + network +
+                ", os=" + os +
+                ", timeProvider=" + timeProvider +
+                ", managerClusterInfo=" + managerClusterInfo +
+                ", kubernetesClusterInfo=" + kubernetesClusterInfo +
+                '}';
     }
 }

--- a/xap-core/xap-common/src/main/java/com/gigaspaces/start/XapNetworkInfo.java
+++ b/xap-core/xap-common/src/main/java/com/gigaspaces/start/XapNetworkInfo.java
@@ -71,4 +71,15 @@ public class XapNetworkInfo {
     public boolean isPublicHostConfigured(){
         return publicHostConfigured;
     }
+
+    @Override
+    public String toString() {
+        return "XapNetworkInfo{" +
+                "hostId='" + hostId + '\'' +
+                ", host=" + host +
+                ", publicHost=" + publicHost +
+                ", publicHostId='" + publicHostId + '\'' +
+                ", publicHostConfigured=" + publicHostConfigured +
+                '}';
+    }
 }

--- a/xap-core/xap-common/src/test/java/com/gigaspaces/logger/GSSimpleFormatterTest.java
+++ b/xap-core/xap-common/src/test/java/com/gigaspaces/logger/GSSimpleFormatterTest.java
@@ -36,4 +36,11 @@ public class GSSimpleFormatterTest {
         Assert.assertTrue("Unescape symbol find!", log.contains("Detected a threat.\\n No action needed."));
     }
 
+    @Test
+    public void formatCEFExtensionValueQuote() {
+        LogRecord logRecord = new LogRecord(Level.INFO, "default message");
+        String log = gsSimpleFormatter.format(logRecord);
+        Assert.assertTrue("Unescape symbol find!", log.contains("msg=\"default message\""));
+    }
+
 }

--- a/xap-core/xap-common/src/test/java/com/gigaspaces/logger/GSSimpleFormatterTest.java
+++ b/xap-core/xap-common/src/test/java/com/gigaspaces/logger/GSSimpleFormatterTest.java
@@ -1,0 +1,39 @@
+package com.gigaspaces.logger;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import static org.junit.Assert.*;
+
+public class GSSimpleFormatterTest {
+
+    public static final String CEF_PATTERN = "{0,date,yyyy-MM-dd HH:mm:ss} {11} CEF:0|gigaspaces|{12}|{13}|0|Legacy Message|{14}|{15}";
+
+    private GSSimpleFormatter gsSimpleFormatter;
+
+    @Before
+    public void setUp() throws Exception {
+        gsSimpleFormatter = new GSSimpleFormatter(CEF_PATTERN);
+    }
+
+    @Test
+    public void formatPipeCEF() {
+        LogRecord logRecord = new LogRecord(Level.INFO, "detected a | in message");
+        String log = gsSimpleFormatter.format(logRecord);
+        Assert.assertTrue("Unescape symbol find!", log.contains("detected a \\| in message"));
+    }
+
+
+    @Test
+    public void formatMultiLineCEF() {
+        LogRecord logRecord = new LogRecord(Level.INFO, "Detected a threat.\n No action needed.");
+        String log = gsSimpleFormatter.format(logRecord);
+        Assert.assertTrue("Unescape symbol find!", log.contains("Detected a threat.\\n No action needed."));
+    }
+
+}

--- a/xap-core/xap-datagrid/src/main/resources/config/log/xap_logging.properties
+++ b/xap-core/xap-datagrid/src/main/resources/config/log/xap_logging.properties
@@ -43,11 +43,19 @@ java.util.logging.ConsoleHandler.formatter = com.gigaspaces.logger.GSSimpleForma
 #  6 - Context
 #  7 - Thread name
 #  8 - Thread id
-# TODO : add new values!
 #  9 - LRMI short invocation context if available (context is traced only if com.gigaspaces.lrmi.context.level>=FINE)
 # 10 - LRMI long invocation context if available (context is traced only if com.gigaspaces.lrmi.context.level>=FINE)
+# 11 - HOST
+# 12 - CEF_VERSION
+# 13 - DEVICE_VENDOR
+# 14 - DEVICE_PRODUCT
+# 15 - DEVICE_VERSION
+# 16 - SIGNATURE_ID
+# 17 - NAME
+# 18 - SEVERITY
 #
 # Example: {0,date} {0,time} {6} Class: {1} Method: {2}\n{3} [{4}]: {5}\n
+# Example of Common Event Format: {0,date,yyyy-MM-dd HH:mm:ss} {11} CEF:{12}|{13}|{14}|{15}|{16}|{17}|{18}|Extension {5}
 # For more details about format, please refer to: java.text.MessageFormat
 # Jan 18 11:07:53 host CEF:Version|Device Vendor|Device Product|Device Version|SignatureID|Name|Severity|Extension
 com.gigaspaces.logger.GSSimpleFormatter.format = {0,date,yyyy-MM-dd HH:mm:ss} {11} CEF:{12}|{13}|{14}|{15}|{16}|{17}|{18}|Extension {5}

--- a/xap-core/xap-datagrid/src/main/resources/config/log/xap_logging.properties
+++ b/xap-core/xap-datagrid/src/main/resources/config/log/xap_logging.properties
@@ -49,6 +49,13 @@ java.util.logging.ConsoleHandler.formatter = com.gigaspaces.logger.GSSimpleForma
 # 12 - DEVICE_PRODUCT the name of the module
 # 13 - DEVICE_VERSION
 # 14 - SEVERITY the number the error level between 0 to 10
+#                SEVERE - 9
+#                WARNING - 5
+#                INFO - 4
+#                CONFIG - 3
+#                FINE - 2
+#                FINER - 1
+#                default -  0
 # 15 - EXTENSION should be in key-value format, with the following keys :
 #                method={class name}.{method name}
 #                context={context} (if not used in the header fields)

--- a/xap-core/xap-datagrid/src/main/resources/config/log/xap_logging.properties
+++ b/xap-core/xap-datagrid/src/main/resources/config/log/xap_logging.properties
@@ -43,12 +43,15 @@ java.util.logging.ConsoleHandler.formatter = com.gigaspaces.logger.GSSimpleForma
 #  6 - Context
 #  7 - Thread name
 #  8 - Thread id
+# TODO : add new values!
 #  9 - LRMI short invocation context if available (context is traced only if com.gigaspaces.lrmi.context.level>=FINE)
 # 10 - LRMI long invocation context if available (context is traced only if com.gigaspaces.lrmi.context.level>=FINE)
 #
 # Example: {0,date} {0,time} {6} Class: {1} Method: {2}\n{3} [{4}]: {5}\n
 # For more details about format, please refer to: java.text.MessageFormat
-com.gigaspaces.logger.GSSimpleFormatter.format = {0,date,yyyy-MM-dd HH:mm:ss,SSS} {6} {3} [{4}] - {5}
+# Jan 18 11:07:53 host CEF:Version|Device Vendor|Device Product|Device Version|SignatureID|Name|Severity|Extension
+com.gigaspaces.logger.GSSimpleFormatter.format = {0,date,yyyy-MM-dd HH:mm:ss} {11} CEF:{12}|{13}|{14}|{15}|{16}|{17}|{18}|Extension {5}
+#com.gigaspaces.logger.GSSimpleFormatter.format = {0,date,yyyy-MM-dd HH:mm:ss,SSS} {6} {3} [{4}] - {5}
 
 ###############################################################################
 # RollingFileHandler properties

--- a/xap-core/xap-datagrid/src/main/resources/config/log/xap_logging.properties
+++ b/xap-core/xap-datagrid/src/main/resources/config/log/xap_logging.properties
@@ -58,7 +58,6 @@ java.util.logging.ConsoleHandler.formatter = com.gigaspaces.logger.GSSimpleForma
 # Example: {0,date} {0,time} {6} Class: {1} Method: {2}\n{3} [{4}]: {5}\n
 # Example of Common Event Format: {0,date,yyyy-MM-dd HH:mm:ss} {11} CEF:0|gigaspaces|{12}|{13}|0|Legacy Message|{14}|{15}
 # For more details about format, please refer to: java.text.MessageFormat
-# Jan 18 11:07:53 host CEF:Version|Device Vendor|Device Product|Device Version|SignatureID|Name|Severity|Extension
 com.gigaspaces.logger.GSSimpleFormatter.format = {0,date,yyyy-MM-dd HH:mm:ss,SSS} {6} {3} [{4}] - {5}
 
 ###############################################################################

--- a/xap-core/xap-datagrid/src/main/resources/config/log/xap_logging.properties
+++ b/xap-core/xap-datagrid/src/main/resources/config/log/xap_logging.properties
@@ -46,20 +46,20 @@ java.util.logging.ConsoleHandler.formatter = com.gigaspaces.logger.GSSimpleForma
 #  9 - LRMI short invocation context if available (context is traced only if com.gigaspaces.lrmi.context.level>=FINE)
 # 10 - LRMI long invocation context if available (context is traced only if com.gigaspaces.lrmi.context.level>=FINE)
 # 11 - HOST
-# 12 - CEF_VERSION
-# 13 - DEVICE_VENDOR
-# 14 - DEVICE_PRODUCT
-# 15 - DEVICE_VERSION
-# 16 - SIGNATURE_ID
-# 17 - NAME
-# 18 - SEVERITY
-#
+# 12 - DEVICE_PRODUCT the name of the module
+# 13 - DEVICE_VERSION
+# 14 - SEVERITY the number the error level between 0 to 10
+# 15 - EXTENSION should be in key-value format, with the following keys :
+#                method={class name}.{method name}
+#                context={context} (if not used in the header fields)
+#                thread={thread id}
+#                msg={message}
+#                LRMI={LRMI long invocation context}
 # Example: {0,date} {0,time} {6} Class: {1} Method: {2}\n{3} [{4}]: {5}\n
-# Example of Common Event Format: {0,date,yyyy-MM-dd HH:mm:ss} {11} CEF:{12}|{13}|{14}|{15}|{16}|{17}|{18}|Extension {5}
+# Example of Common Event Format: {0,date,yyyy-MM-dd HH:mm:ss} {11} CEF:0|gigaspaces|{12}|{13}|0|Legacy Message|{14}|{15}
 # For more details about format, please refer to: java.text.MessageFormat
 # Jan 18 11:07:53 host CEF:Version|Device Vendor|Device Product|Device Version|SignatureID|Name|Severity|Extension
-com.gigaspaces.logger.GSSimpleFormatter.format = {0,date,yyyy-MM-dd HH:mm:ss} {11} CEF:{12}|{13}|{14}|{15}|{16}|{17}|{18}|Extension {5}
-#com.gigaspaces.logger.GSSimpleFormatter.format = {0,date,yyyy-MM-dd HH:mm:ss,SSS} {6} {3} [{4}] - {5}
+com.gigaspaces.logger.GSSimpleFormatter.format = {0,date,yyyy-MM-dd HH:mm:ss,SSS} {6} {3} [{4}] - {5}
 
 ###############################################################################
 # RollingFileHandler properties


### PR DESCRIPTION
The CEF logging is optional and can be provided as a logger class that may be configured to be active when CEF format is required.

Backward compatibility must be maintained, so existing installation will not have a different log format after upgrading.

It is also required that the actual format of CEF (which fields and extensions, constants, etc.) will be controlled from configuring that class and not be within the code.