### PR TITLE
PRX-162 : Comarch - allow extending an abstract class for a broadcast table

### DIFF
--- a/xap-core/xap-datagrid/src/main/java/com/gigaspaces/internal/metadata/SpaceTypeInfo.java
+++ b/xap-core/xap-datagrid/src/main/java/com/gigaspaces/internal/metadata/SpaceTypeInfo.java
@@ -1416,8 +1416,12 @@ public class SpaceTypeInfo implements SmartExternalizable {
             validatePropertyCombination(_persistProperty, idProperty, "persist", "id");
         validatePropertyCombination(_persistProperty, _routingProperty, "persist", "routing");
 
-        if(isBroadcast())
+        if(isBroadcast()) {
             validateBroadcastTable();
+        } else {
+            validateNonBroadcastTable();
+        }
+
 
         if (_idAutoGenerate) {
             validateGetterSetter(_idProperties.get(0), "Id", ConstructorPropertyValidation.REQUIERS_SETTER);
@@ -1482,7 +1486,9 @@ public class SpaceTypeInfo implements SmartExternalizable {
     }
 
     private void validateBroadcastTable() {
-        if(_superTypeInfo._superTypeInfo != null && !_superTypeInfo._superTypeInfo.isBroadcast())
+        if(_superTypeInfo != null &&
+                !_superTypeInfo.getType().equals(Object.class) &&
+                !_superTypeInfo.isBroadcast())
             throw new SpaceMetadataValidationException(_type, "Broadcast table cannot extend non broadcast table.");
         if(_routingProperty != null)
             throw new SpaceMetadataValidationException(_type, "Routing property and broadcast table cannot be used together.");
@@ -1490,6 +1496,11 @@ public class SpaceTypeInfo implements SmartExternalizable {
             throw new SpaceMetadataValidationException(_type, "Auto generated id and broadcast table cannot be used together.");
         if(!_persist)
             throw new SpaceMetadataValidationException(_type, "Broadcast table cannot be transient.");
+    }
+
+    private void validateNonBroadcastTable() {
+        if(!this.isBroadcast() && _superTypeInfo != null && _superTypeInfo.isBroadcast())
+            throw new SpaceMetadataValidationException(_type, "Non broadcast table cannot extend broadcast table.");
     }
 
     private void validateGetterSetter(SpacePropertyInfo property, String propertyDesc, ConstructorPropertyValidation validation) {

--- a/xap-core/xap-datagrid/src/test/java/com/gigaspaces/metadata/SpaceTypeInfoTestCase.java
+++ b/xap-core/xap-datagrid/src/test/java/com/gigaspaces/metadata/SpaceTypeInfoTestCase.java
@@ -24,6 +24,8 @@ import com.gigaspaces.internal.query.valuegetter.SpaceEntryPathGetter;
 import com.gigaspaces.metadata.annotated.PojoAttributes;
 import com.gigaspaces.metadata.annotated.PojoAttributesInheritence1;
 import com.gigaspaces.metadata.annotated.PojoAttributesInheritence2;
+import com.gigaspaces.metadata.annotated.PojoBroadcast;
+import com.gigaspaces.metadata.annotated.PojoBroadcastExtendNonBroadcastInvalid;
 import com.gigaspaces.metadata.annotated.PojoCommonProperties;
 import com.gigaspaces.metadata.annotated.PojoCommonPropertiesInheritence;
 import com.gigaspaces.metadata.annotated.PojoCustomIndex;
@@ -83,6 +85,7 @@ import com.gigaspaces.metadata.annotated.PojoInvalid.InvalidVersionWithPersist;
 import com.gigaspaces.metadata.annotated.PojoInvalid.InvalidVersionWithRouting;
 import com.gigaspaces.metadata.annotated.PojoInvalid.InvalidVersionWithSpaceProperty;
 import com.gigaspaces.metadata.annotated.PojoMultipleSpaceIndexes;
+import com.gigaspaces.metadata.annotated.PojoNonBroadcastExtendBroadcastInvalid;
 import com.gigaspaces.metadata.annotated.PojoRoutingIndexExplicit;
 import com.gigaspaces.metadata.annotated.PojoRoutingIndexImplicit;
 import com.gigaspaces.metadata.annotated.PojoSpaceIndex;
@@ -1138,5 +1141,42 @@ public class SpaceTypeInfoTestCase extends TestCase {
 
     }
 
+    ///////////////////////////////////
+    //     Broadcast Table Tests     //
+    ///////////////////////////////////
+
+    public void testBroadcastExtendsNonBroadcastRestriction() {
+        final Class<?> type = PojoBroadcastExtendNonBroadcastInvalid.class;
+
+        // Act:
+        try {
+            SpaceTypeInfoRepository.getTypeInfo(type);
+            Assert.fail("SpaceMetadataValidationException should have been thrown.");
+        } catch (SpaceMetadataValidationException e) {
+            Assert.assertEquals(String.format("Invalid metadata for class [%s]: Broadcast table cannot extend non broadcast table.", type.getName()), e.getMessage());
+        }
+    }
+
+    public void testNonBroadcastExtendsBroadcastRestriction() {
+        final Class<?> type = PojoNonBroadcastExtendBroadcastInvalid.class;
+
+        // Act:
+        try {
+            SpaceTypeInfoRepository.getTypeInfo(type);
+            Assert.fail("SpaceMetadataValidationException should have been thrown.");
+        } catch (SpaceMetadataValidationException e) {
+            Assert.assertEquals(String.format("Invalid metadata for class [%s]: Non broadcast table cannot extend broadcast table.", type.getName()), e.getMessage());
+        }
+    }
+
+    public void testBroadcastExtendsPossibility() {
+        final Class<?> type = PojoBroadcast.class;
+
+        // Act:
+        SpaceTypeInfo typeInfo = SpaceTypeInfoRepository.getTypeInfo(type);
+        Assert.assertTrue("Pojo should be marked as broadcast.", typeInfo.isBroadcast());
+        Assert.assertNotNull("Pojo's super class type info shouldn't be null.", typeInfo.getSuperTypeInfo());
+        Assert.assertTrue("Pojo's super class should be marked as broadcast.", typeInfo.getSuperTypeInfo().isBroadcast());
+    }
 
 }

--- a/xap-core/xap-datagrid/src/test/java/com/gigaspaces/metadata/annotated/PojoBroadcast.java
+++ b/xap-core/xap-datagrid/src/test/java/com/gigaspaces/metadata/annotated/PojoBroadcast.java
@@ -1,0 +1,8 @@
+package com.gigaspaces.metadata.annotated;
+
+import com.gigaspaces.annotation.pojo.SpaceClass;
+
+@SpaceClass(broadcast = true)
+@com.gigaspaces.api.InternalApi
+public class PojoBroadcast extends PojoBroadcastParent {
+}

--- a/xap-core/xap-datagrid/src/test/java/com/gigaspaces/metadata/annotated/PojoBroadcastExtendNonBroadcastInvalid.java
+++ b/xap-core/xap-datagrid/src/test/java/com/gigaspaces/metadata/annotated/PojoBroadcastExtendNonBroadcastInvalid.java
@@ -1,0 +1,8 @@
+package com.gigaspaces.metadata.annotated;
+
+import com.gigaspaces.annotation.pojo.SpaceClass;
+
+@SpaceClass(broadcast = true)
+@com.gigaspaces.api.InternalApi
+public class PojoBroadcastExtendNonBroadcastInvalid extends PojoNonBroadcast {
+}

--- a/xap-core/xap-datagrid/src/test/java/com/gigaspaces/metadata/annotated/PojoBroadcastParent.java
+++ b/xap-core/xap-datagrid/src/test/java/com/gigaspaces/metadata/annotated/PojoBroadcastParent.java
@@ -1,0 +1,8 @@
+package com.gigaspaces.metadata.annotated;
+
+import com.gigaspaces.annotation.pojo.SpaceClass;
+
+@SpaceClass(broadcast = true)
+@com.gigaspaces.api.InternalApi
+public class PojoBroadcastParent {
+}

--- a/xap-core/xap-datagrid/src/test/java/com/gigaspaces/metadata/annotated/PojoNonBroadcast.java
+++ b/xap-core/xap-datagrid/src/test/java/com/gigaspaces/metadata/annotated/PojoNonBroadcast.java
@@ -1,0 +1,8 @@
+package com.gigaspaces.metadata.annotated;
+
+import com.gigaspaces.annotation.pojo.SpaceClass;
+
+@SpaceClass(broadcast = false)
+@com.gigaspaces.api.InternalApi
+public class PojoNonBroadcast {
+}

--- a/xap-core/xap-datagrid/src/test/java/com/gigaspaces/metadata/annotated/PojoNonBroadcastExtendBroadcastInvalid.java
+++ b/xap-core/xap-datagrid/src/test/java/com/gigaspaces/metadata/annotated/PojoNonBroadcastExtendBroadcastInvalid.java
@@ -1,0 +1,8 @@
+package com.gigaspaces.metadata.annotated;
+
+import com.gigaspaces.annotation.pojo.SpaceClass;
+
+@SpaceClass(broadcast = false)
+@com.gigaspaces.api.InternalApi
+public class PojoNonBroadcastExtendBroadcastInvalid extends PojoBroadcast {
+}


### PR DESCRIPTION
Couldn't extend broadcast table because of the following validation :
if (this._superTypeInfo._superTypeInfo != null && !this._superTypeInfo._superTypeInfo.isBroadcast())

Every class that extends another class, must put the broadcast annotation on super class since eventually, every class extends Object we will always fail in case we are trying to write a table that extends any other class.

Broadcast table can extend only Broadcast Table
Non Broadcast table can't extend Broadcast Table