### PR TITLE
PIC-919 Get TieredStorageConfig from ProxySettings

### DIFF
--- a/xap-core/xap-datagrid/src/main/java/com/gigaspaces/client/iterator/SpaceEntryPacketIterator.java
+++ b/xap-core/xap-datagrid/src/main/java/com/gigaspaces/client/iterator/SpaceEntryPacketIterator.java
@@ -76,7 +76,7 @@ public class SpaceEntryPacketIterator implements IEntryPacketIterator {
         this._readModifiers = modifiers;
         this._queryPacket = toTemplatePacket(query);
         this._queryResultType = _queryPacket.getQueryResultType();
-        this._isTiered = _spaceProxy.getDirectProxy().getProxySettings().getSpaceAttributes().isTieredStorageCachePolicy();
+        this._isTiered = _spaceProxy.getDirectProxy().getProxySettings().isTieredStorageCachePolicy();
         this._iteratorResult = initialize();
         this._bufferIterator = _iteratorResult.getEntries().iterator();
     }

--- a/xap-core/xap-datagrid/src/main/java/com/gigaspaces/internal/client/spaceproxy/SpaceProxyImpl.java
+++ b/xap-core/xap-datagrid/src/main/java/com/gigaspaces/internal/client/spaceproxy/SpaceProxyImpl.java
@@ -418,11 +418,6 @@ public class SpaceProxyImpl extends AbstractDirectSpaceProxy implements SameProx
     }
 
     public void beforeSpaceAction(CommonProxyActionInfo action) {
-        //TODO: @sagiv/@tomer PIC-809 currently we start support txn, remove this when we done -
-        // considering block distributed txn.
-//        if(action.txn != null && this.getProxySettings().getSpaceAttributes().isTieredStorageCachePolicy()){
-//           throw new TieredStorageOperationException("Transactions are not supported with tiered storage at this stage");
-//        }
         action.txn = _transactionManager.beforeSpaceAction(action.txn);
     }
 

--- a/xap-core/xap-datagrid/src/main/java/com/gigaspaces/internal/server/space/SpaceEngine.java
+++ b/xap-core/xap-datagrid/src/main/java/com/gigaspaces/internal/server/space/SpaceEngine.java
@@ -388,8 +388,7 @@ public class SpaceEngine implements ISpaceModeListener , IClusterInfoChangedList
 
 
     private void createTieredStorageManager() throws IllegalAccessException, InstantiationException, ClassNotFoundException {
-        final boolean isTieredStorage = String.valueOf(CACHE_POLICY_TIERED_STORAGE)
-                .equals(_spaceImpl.getJspaceAttr().getCustomProperties().get(FULL_CACHE_POLICY_PROP));
+        final boolean isTieredStorage = _spaceImpl.getJspaceAttr().isTieredStorageCachePolicy();
         if (isTieredStorage) {
             TieredStorageConfig tieredStorageConfig = _spaceImpl.getJspaceAttr().getTieredStorageConfig();
             if (tieredStorageConfig == null) {

--- a/xap-core/xap-datagrid/src/main/java/com/j_spaces/core/JSpaceAttributes.java
+++ b/xap-core/xap-datagrid/src/main/java/com/j_spaces/core/JSpaceAttributes.java
@@ -1284,13 +1284,10 @@ public class JSpaceAttributes
         return String.valueOf(Constants.CacheManager.CACHE_POLICY_TIERED_STORAGE).equals(cachePolicyValue);
     }
 
-    public void setTieredStorageConfig(TieredStorageConfig tieredStorageConfig) {
-        put(FULL_TIERED_STORAGE_TABLE_CONFIG_INSTANCE_PROP, tieredStorageConfig);
-    }
-
     public TieredStorageConfig getTieredStorageConfig() {
         return ((TieredStorageConfig) getOrDefault(FULL_TIERED_STORAGE_TABLE_CONFIG_INSTANCE_PROP,
-                _customProperties.get(FULL_TIERED_STORAGE_TABLE_CONFIG_INSTANCE_PROP)));
+                _customProperties.getOrDefault(FULL_TIERED_STORAGE_TABLE_CONFIG_INSTANCE_PROP,
+                        new TieredStorageConfig())));
 
     }
 

--- a/xap-core/xap-datagrid/src/main/java/com/j_spaces/core/client/ProxySettings.java
+++ b/xap-core/xap-datagrid/src/main/java/com/j_spaces/core/client/ProxySettings.java
@@ -22,10 +22,12 @@ import com.gigaspaces.internal.cluster.SpaceClusterInfo;
 import com.gigaspaces.internal.lrmi.stubs.LRMISpaceImpl;
 import com.gigaspaces.internal.server.space.IRemoteSpace;
 import com.gigaspaces.internal.server.space.SpaceImpl;
+import com.gigaspaces.internal.server.space.tiered_storage.TieredStorageConfig;
 import com.gigaspaces.internal.version.PlatformLogicalVersion;
 import com.gigaspaces.lrmi.LRMIInvocationContext;
 import com.gigaspaces.lrmi.RemoteStub;
 import com.gigaspaces.serialization.SmartExternalizable;
+import com.j_spaces.core.Constants;
 import com.j_spaces.core.IJSpaceContainer;
 import com.j_spaces.core.IStubHandler;
 import com.j_spaces.core.admin.SpaceConfig;
@@ -33,11 +35,13 @@ import com.j_spaces.core.cluster.LBProxyHolder;
 import com.j_spaces.kernel.SystemProperties;
 import net.jini.id.Uuid;
 
-import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Properties;
+
+import static com.j_spaces.core.Constants.CacheManager.FULL_CACHE_POLICY_PROP;
+import static com.j_spaces.core.Constants.TieredStorage.FULL_TIERED_STORAGE_TABLE_CONFIG_INSTANCE_PROP;
 
 /**
  * Essential proxy settings. This class is not serializable and is not passed between the space and
@@ -223,6 +227,18 @@ public class ProxySettings implements SmartExternalizable {
 
     public Properties getCustomProperties() {
         return _customProperties;
+    }
+
+    public boolean isTieredStorageCachePolicy() {
+        final String cachePolicyValue = _customProperties.getProperty(FULL_CACHE_POLICY_PROP);
+        return String.valueOf(Constants.CacheManager.CACHE_POLICY_TIERED_STORAGE).equals(cachePolicyValue)
+                || getSpaceAttributes().isTieredStorageCachePolicy();
+    }
+
+    public TieredStorageConfig getTieredStorageConfig() {
+        Object config = _customProperties.get(FULL_TIERED_STORAGE_TABLE_CONFIG_INSTANCE_PROP);
+        if (config != null) return ((TieredStorageConfig) config);
+        return getSpaceAttributes().getTieredStorageConfig();
     }
 
     @Override

--- a/xap-core/xap-datagrid/src/main/java/com/j_spaces/core/client/ProxySettings.java
+++ b/xap-core/xap-datagrid/src/main/java/com/j_spaces/core/client/ProxySettings.java
@@ -237,8 +237,7 @@ public class ProxySettings implements SmartExternalizable {
 
     public TieredStorageConfig getTieredStorageConfig() {
         Object config = _customProperties.get(FULL_TIERED_STORAGE_TABLE_CONFIG_INSTANCE_PROP);
-        if (config != null) return ((TieredStorageConfig) config);
-        return getSpaceAttributes().getTieredStorageConfig();
+        return config != null ? ((TieredStorageConfig) config) : getSpaceAttributes().getTieredStorageConfig();
     }
 
     @Override

--- a/xap-core/xap-datagrid/src/main/java/com/j_spaces/core/client/ProxySettings.java
+++ b/xap-core/xap-datagrid/src/main/java/com/j_spaces/core/client/ProxySettings.java
@@ -236,8 +236,8 @@ public class ProxySettings implements SmartExternalizable {
     }
 
     public TieredStorageConfig getTieredStorageConfig() {
-        Object config = _customProperties.get(FULL_TIERED_STORAGE_TABLE_CONFIG_INSTANCE_PROP);
-        return config != null ? ((TieredStorageConfig) config) : getSpaceAttributes().getTieredStorageConfig();
+        TieredStorageConfig config = (TieredStorageConfig) _customProperties.get(FULL_TIERED_STORAGE_TABLE_CONFIG_INSTANCE_PROP);
+        return config != null ? config : getSpaceAttributes().getTieredStorageConfig();
     }
 
     @Override


### PR DESCRIPTION
Extract TieredStorageConfig from custom properties of ProxySettings.
If not found, try attributes of SpaceConfig which also has custom properties,
by default always return an empty TieredStorageConfig to avoid NPE.