### PR TITLE
PIC-1031 Support disabling codebase field

### DIFF
--- a/xap-core/xap-datagrid/src/main/java/com/sun/jini/reggie/EntryClassBase.java
+++ b/xap-core/xap-datagrid/src/main/java/com/sun/jini/reggie/EntryClassBase.java
@@ -28,6 +28,8 @@ import java.rmi.server.RMIClassLoader;
 @com.gigaspaces.api.InternalApi
 public class EntryClassBase implements Serializable {
 
+    private static final boolean support_code_base = Boolean.getBoolean("com.gs.transport_protocol.lrmi.support-codebase");
+
     private static final long serialVersionUID = 2L;
 
     /**
@@ -55,7 +57,7 @@ public class EntryClassBase implements Serializable {
      * Sets the codebase to the codebase of the given class.
      */
     public void setCodebase(Class cls) {
-        codebase = RMIClassLoader.getClassAnnotation(cls);
+        codebase = support_code_base ? RMIClassLoader.getClassAnnotation(cls) : null;
     }
 
     /**

--- a/xap-core/xap-datagrid/src/main/java/com/sun/jini/reggie/ServiceTypeBase.java
+++ b/xap-core/xap-datagrid/src/main/java/com/sun/jini/reggie/ServiceTypeBase.java
@@ -28,6 +28,8 @@ import java.rmi.server.RMIClassLoader;
 @com.gigaspaces.api.InternalApi
 public class ServiceTypeBase implements Serializable {
 
+    private static final boolean support_code_base = Boolean.getBoolean("com.gs.transport_protocol.lrmi.support-codebase");
+
     private static final long serialVersionUID = 2L;
 
     /**
@@ -55,7 +57,7 @@ public class ServiceTypeBase implements Serializable {
      * Sets the codebase to the codebase of the given class.
      */
     public void setCodebase(Class cls) {
-        codebase = RMIClassLoader.getClassAnnotation(cls);
+        codebase = support_code_base ? RMIClassLoader.getClassAnnotation(cls) : null;
     }
 
     /**


### PR DESCRIPTION
Respect the property com.gs.transport_protocol.lrmi.support-codebase when setting the code base. If this property is false, no code base will be set. See also AnnotatedObjectOutputStream#writeAnnotation(Class)