### PR TITLE
PIC-1053 revert and re-introduce bug

### DIFF
--- a/xap-core/xap-datagrid/src/main/java/com/gigaspaces/internal/server/space/SpaceImpl.java
+++ b/xap-core/xap-datagrid/src/main/java/com/gigaspaces/internal/server/space/SpaceImpl.java
@@ -3107,8 +3107,8 @@ public class SpaceImpl extends AbstractService implements IRemoteSpace, IInterna
             //FIX for GS-11826
             //Cause to SpaceConfig initialization if cachePolicy is BlobStore and devices still were not initialized
             if (_spaceConfig != null
-                    && _spaceConfig.getCachePolicy().equals(String.valueOf(CACHE_POLICY_BLOB_STORE))
-                    && _spaceConfig.getBlobStoreDevices() == null) {
+                    && _spaceConfig.getCachePolicy().equals(CACHE_POLICY_BLOB_STORE)
+                    && _spaceConfig.getBlobStoreDevices() == null) { //TODO PIC-1053 this line is never true
                 _spaceConfig = null;
             }
 


### PR DESCRIPTION
The getConfig method tries to populate the SpaceConfig when blobstore devices is null. But the if-statement was never true, so the handling was ignored. Fixing the if-statement to use proper String equality causes the SpaceConfig to be created again and again since blobstore devices is always null (no longer used property).

for 16.2 GA, re-introduce equality bug and SpaceConfig will be cached in the first iteration.