### PR TITLE
PIC-1053 remove handling of SpaceConfig for old blobstore configuration

### DIFF
--- a/xap-core/xap-datagrid/src/main/java/com/gigaspaces/internal/server/space/SpaceImpl.java
+++ b/xap-core/xap-datagrid/src/main/java/com/gigaspaces/internal/server/space/SpaceImpl.java
@@ -3104,14 +3104,6 @@ public class SpaceImpl extends AbstractService implements IRemoteSpace, IInterna
     @Override
     public SpaceConfig getConfig() {
         synchronized (this) {
-            //FIX for GS-11826
-            //Cause to SpaceConfig initialization if cachePolicy is BlobStore and devices still were not initialized
-            if (_spaceConfig != null
-                    && _spaceConfig.getCachePolicy().equals(CACHE_POLICY_BLOB_STORE)
-                    && _spaceConfig.getBlobStoreDevices() == null) { //TODO PIC-1053 this line is never true
-                _spaceConfig = null;
-            }
-
             if (_spaceConfig != null) {
                 return _spaceConfig;
             }


### PR DESCRIPTION
There are three types of blobstore test suites:
1. (mx-pmem) for pmem-blobstore,
2. (rocksdb, demote-rocksdb) for rocksdb-blobstore,
3. (off-heap) for offheap-blobstore