### PR TITLE
Upgrade JNA to latest version 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <oshi.version>5.5.0</oshi.version>
         <slf4j.version>1.7.26</slf4j.version>
-        <jna.version>5.6.0</jna.version>
+        <jna.version>5.13.0</jna.version>
         <spring.version>5.3.19</spring.version>
         <spring.security.version>5.6.2</spring.security.version>
         <junit.version>4.12</junit.version>


### PR DESCRIPTION
Upgrade JNA lib to latest version to avoid problems when running gigaspaces tests using testcontainers on apple mac M1

The 5.6.0 version of jna doesn't work on apple mac m1, this is fixed in 5.7.0, but this commit suggests upgrading to the latest version, which currently is 5.13.0

jna has no transitive dependencies and jna release notes does not mention any problems upgrading to 5.13.0

for more info:

https://github.com/java-native-access/jna/blob/master/CHANGES.md 
https://github.com/java-native-access/jna/pull/1238 
https://www.testcontainers.org/