### PR TITLE
WIP: PIC-2427:  locked actions for older generations are not allowed

### DIFF
--- a/xap-core/xap-datagrid/src/main/java/com/gigaspaces/internal/server/space/SpaceImpl.java
+++ b/xap-core/xap-datagrid/src/main/java/com/gigaspaces/internal/server/space/SpaceImpl.java
@@ -128,7 +128,6 @@ import com.gigaspaces.security.authorities.Privilege;
 import com.gigaspaces.security.authorities.SpaceAuthority.SpacePrivilege;
 import com.gigaspaces.security.directory.CredentialsProvider;
 import com.gigaspaces.security.directory.CredentialsProviderHelper;
-import com.gigaspaces.security.service.SecurityContext;
 import com.gigaspaces.security.service.SecurityInterceptor;
 import com.gigaspaces.server.space.suspend.SuspendType;
 import com.gigaspaces.start.SystemInfo;
@@ -2593,12 +2592,12 @@ public class SpaceImpl extends AbstractService implements IRemoteSpace, IInterna
         return MVCCUtils.getMVCCEntryMetaData(getEngine(), typeName, id);
     }
 
-    public boolean isMVCCEntryDirtyUnderTransaction(String typeName, Object id, long transactionId) {
-        return MVCCUtils.isMVCCEntryDirtyUnderTransaction(getEngine(), typeName, id, transactionId);
+    public MVCCEntryMetaData getMVCCDirtyEntryMetaDataUnderTransaction(String typeName, Object id, long transactionId) {
+        return MVCCUtils.getMVCCDirtyEntryUnderTransaction(getEngine(), typeName, id, transactionId);
     }
 
-    public MVCCEntryMetaData getDirtyEntryMetaData(String typeName, Object id) {
-        return MVCCUtils.getDirtyEntryMetaData(getEngine(), typeName, id);
+    public MVCCEntryMetaData getMVCCDirtyEntryMetaData(String typeName, Object id) {
+        return MVCCUtils.getMVCCDirtyEntryMetaData(getEngine(), typeName, id);
     }
 
     public GSEventRegistration notify(ITemplatePacket template, Transaction txn, long lease, SpaceContext sc,

--- a/xap-core/xap-datagrid/src/main/java/com/gigaspaces/internal/server/space/executors/SpaceGetMVCCEntryMetaDataExecutor.java
+++ b/xap-core/xap-datagrid/src/main/java/com/gigaspaces/internal/server/space/executors/SpaceGetMVCCEntryMetaDataExecutor.java
@@ -1,6 +1,7 @@
 package com.gigaspaces.internal.server.space.executors;
 
 import com.gigaspaces.internal.server.space.SpaceImpl;
+import com.gigaspaces.internal.server.storage.MVCCEntryMetaData;
 import com.gigaspaces.internal.space.requests.GetMVCCEntryMetaDataRequestInfo;
 import com.gigaspaces.internal.space.requests.SpaceRequestInfo;
 import com.gigaspaces.internal.space.responses.GetMVCCEntryMetaDataResponseInfo;
@@ -14,9 +15,8 @@ public class SpaceGetMVCCEntryMetaDataExecutor extends SpaceActionExecutor{
         GetMVCCEntryMetaDataRequestInfo request = (GetMVCCEntryMetaDataRequestInfo) spaceRequestInfo;
         for (Object id : request.getIds()) {
             response.addEntryMetaData(id, space.getMVCCEntryMetaData(request.getTypeName(), id));
-            if (space.isMVCCEntryDirtyUnderTransaction(request.getTypeName(), id, request.getTransactionId())) {
-                response.addDirtyMetaData(id, space.getDirtyEntryMetaData(request.getTypeName(), id));
-            }
+            MVCCEntryMetaData mvccDirtyEntryMetaDataUnderTransaction = space.getMVCCDirtyEntryMetaDataUnderTransaction(request.getTypeName(), id, request.getTransactionId());
+            response.addDirtyMetaData(id, mvccDirtyEntryMetaDataUnderTransaction);
         }
         return response;
     }

--- a/xap-core/xap-datagrid/src/main/java/com/j_spaces/core/cache/mvcc/MVCCEntryHolder.java
+++ b/xap-core/xap-datagrid/src/main/java/com/j_spaces/core/cache/mvcc/MVCCEntryHolder.java
@@ -1,10 +1,7 @@
 package com.j_spaces.core.cache.mvcc;
 
 import com.gigaspaces.internal.server.metadata.IServerTypeDesc;
-import com.gigaspaces.internal.server.storage.EntryHolder;
-import com.gigaspaces.internal.server.storage.FlatEntryData;
-import com.gigaspaces.internal.server.storage.IEntryHolder;
-import com.gigaspaces.internal.server.storage.ITransactionalEntryData;
+import com.gigaspaces.internal.server.storage.*;
 import com.gigaspaces.internal.utils.Textualizer;
 import com.j_spaces.core.Constants;
 import com.j_spaces.core.server.transaction.EntryXtnInfo;
@@ -45,6 +42,15 @@ public class MVCCEntryHolder extends EntryHolder implements IMVCCLockObject {
                 this.isTransient(), ed);
         dummy.setLogicallyDeleted(true);
         return dummy;
+    }
+
+    public MVCCEntryMetaData toMVCCEntryMetaData() {
+        MVCCEntryMetaData mvccDirtyEntryMetaData = new MVCCEntryMetaData();
+        mvccDirtyEntryMetaData.setCommittedGeneration(this.getCommittedGeneration());
+        mvccDirtyEntryMetaData.setOverrideGeneration(this.getOverrideGeneration());
+        mvccDirtyEntryMetaData.setLogicallyDeleted(this.isLogicallyDeleted());
+        mvccDirtyEntryMetaData.setOverridingAnother(this.isOverridingAnother());
+        return mvccDirtyEntryMetaData;
     }
 
     @Override


### PR DESCRIPTION
- refactor: replace isMVCCEntryDirtyUnderTransaction with getMVCCDirtyEntryMetaDataUnderTransaction;