### PR TITLE
Fix non-descriptive method names

### DIFF
--- a/xap-core/xap-datagrid/src/main/java/com/gigaspaces/cluster/activeelection/PriorityElectionFilter.java
+++ b/xap-core/xap-datagrid/src/main/java/com/gigaspaces/cluster/activeelection/PriorityElectionFilter.java
@@ -36,12 +36,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * This election decision filter provides the condition to aquire desired space state on
+ * This election decision filter provides the condition to acquire desired space state on
  * NamingService. The state will be acquired only if {@link #isAcceptable(ActiveElectionState.State,
  * List)} returns true. <p> The final Primary space status will be acquired only if
  * ActiveElectionState.State.ACTIVE will be accepted. <p> NOTE: The member with {@link
  * ISpaceState#STARTED} of {@link com.j_spaces.lookup.entry.State} or with lower order memberID in
- * fail-over group is acceptable to advance to <code>aquireState</code>.
+ * fail-over group is acceptable to advance to <code>acquireState</code>.
  *
  * @author Igor Goldenberg
  * @version 1.0
@@ -67,16 +67,16 @@ public class PriorityElectionFilter
     }
 
     /**
-     * This method provides the condition to advance the manage member to <code>aquireState</code>
+     * This method provides the condition to advance the manage member to <code>acquireState</code>
      * state.
      *
-     * @param candidateSrv the candidates to aquire desired state.
-     * @param aquireState  the state to aquire.
-     * @return <code>true</code> if the manage member is acceptable to aquire desired
-     * <code>aquireState</code> state.
+     * @param candidateSrv the candidates to acquire desired state.
+     * @param acquireState  the state to acquire.
+     * @return <code>true</code> if the manage member is acceptable to acquire desired
+     * <code>acquireState</code> state.
      **/
     @Override
-    public boolean isAcceptable(ActiveElectionState.State aquireState, List<ServiceItem> candidateSrv) {
+    public boolean isAcceptable(ActiveElectionState.State acquireState, List<ServiceItem> candidateSrv) {
         final String STARTED_STATE = JSpaceState.convertToString(ISpaceState.STARTED);
 
 	  /* prepare sorted candidate list */
@@ -102,13 +102,13 @@ public class PriorityElectionFilter
 
         if (_logger.isDebugEnabled()) {
             _logger.debug("PriorityElectionFilter - " +
-                    "\n Member: [" + _memberName + "] ask to acquire [" + aquireState + "] state." +
+                    "\n Member: [" + _memberName + "] ask to acquire [" + acquireState + "] state." +
                     "\n OrderId: " + orderId +
                     "\n Candidates: " + orderedMemberList +
                     "\n Acquire accepted: " + (orderId == 0));
         }
 	 
-	  /* acceptable to aquire the state, only if index==0 */
+	  /* acceptable to acquire the state, only if index==0 */
         return orderId == 0;
     }
 

--- a/xap-core/xap-datagrid/src/main/java/com/gigaspaces/cluster/activeelection/core/ActiveElectionConfig.java
+++ b/xap-core/xap-datagrid/src/main/java/com/gigaspaces/cluster/activeelection/core/ActiveElectionConfig.java
@@ -167,7 +167,7 @@ public class ActiveElectionConfig implements SmartExternalizable {
     }
 
     /**
-     * Time to yield to other participants between every election phase(total 3) before aquire
+     * Time to yield to other participants between every election phase(total 3) before acquire
      * Primary or Backup state.
      *
      * @param yieldTime time in milliseconds.

--- a/xap-core/xap-datagrid/src/main/java/com/gigaspaces/cluster/activeelection/core/ActiveElectionState.java
+++ b/xap-core/xap-datagrid/src/main/java/com/gigaspaces/cluster/activeelection/core/ActiveElectionState.java
@@ -30,7 +30,7 @@ import java.io.ObjectOutput;
 /**
  * The election state <i>attribute</i> registered in conjunction with service candidate. This state
  * managed by {@link ActiveElectionManager} and modified on Naming service if the candidate service
- * aquire a new state. <p> The following states are available: <li>NONE 	- The service is not
+ * acquire a new state. <p> The following states are available: <li>NONE 	- The service is not
  * initialized yet.</li> <li>PENDING - The service is a candidate to acquire PREPARE state.</li>
  * <li>PREPARE - The service is a candidate to acquire an ACTIVE state.</li> <li>ACTIVE  - The
  * service become to be an ACTIVE.</li> <p>

--- a/xap-core/xap-datagrid/src/main/java/com/gigaspaces/cluster/activeelection/core/IActiveElectionDecisionFilter.java
+++ b/xap-core/xap-datagrid/src/main/java/com/gigaspaces/cluster/activeelection/core/IActiveElectionDecisionFilter.java
@@ -25,7 +25,7 @@ import java.util.List;
 
 /**
  * This interface provides an acceptable decision for the proposed service candidate to
- * advance(aquire) the desired {@link ActiveElectionState.State} state.<br> The filter
+ * advance(acquire) the desired {@link ActiveElectionState.State} state.<br> The filter
  * implementation invokes by {@link ActiveElectionManager} to identify whether the managed service
  * candidate is acceptable to advance current state to <code>advanceState</code>.<br> The state will
  * be advanced by service <b>only</b> if {@link #isAcceptable(ActiveElectionState.State, List)}
@@ -42,8 +42,8 @@ public interface IActiveElectionDecisionFilter {
      * Returns <code>true</code> if the managed service is acceptable to advance the state to
      * <code>advanceState</code>.
      *
-     * @param advanceState The advance state (The state to aquire).
-     * @param candidateSrv The service candidates to aquire <code>advanceState</code>.
+     * @param advanceState The advance state (The state to acquire).
+     * @param candidateSrv The service candidates to acquire <code>advanceState</code>.
      * @return <code>true</code> if the <code>advanceState</code> is acceptable by this filter.
      **/
     public boolean isAcceptable(ActiveElectionState.State advanceState, List<ServiceItem> candidateSrv);

--- a/xap-core/xap-datagrid/src/main/java/com/gigaspaces/internal/cluster/node/impl/router/AbstractScheduledPoolConnectionMonitor.java
+++ b/xap-core/xap-datagrid/src/main/java/com/gigaspaces/internal/cluster/node/impl/router/AbstractScheduledPoolConnectionMonitor.java
@@ -187,7 +187,7 @@ public abstract class AbstractScheduledPoolConnectionMonitor<T, L>
     }
 
     public void close() {
-        //Aquire lock on pool so it wont be executed concurrently
+        //acquire lock on pool so it wont be executed concurrently
         synchronized (_pool) {
             if (_closed)
                 return;

--- a/xap-core/xap-datagrid/src/main/java/com/gigaspaces/lrmi/DynamicSmartStub.java
+++ b/xap-core/xap-datagrid/src/main/java/com/gigaspaces/lrmi/DynamicSmartStub.java
@@ -79,7 +79,7 @@ import org.slf4j.LoggerFactory;
  * #writeExternal(java.io.ObjectOutput)} method the {@link #getLocalObjImpl()} will be exported to
  * the underlying transport protocol. The serialization process is an indication for
  * DynamicSmartStub about exiting out side from local JVM.<br> On deserialization the
- * DynamicSmartStub will try to aquire the direct localObject reference from the underlying
+ * DynamicSmartStub will try to acquire the direct localObject reference from the underlying
  * transport protocol. If direct reference wasn't acquired, it means the stub instance is not in
  * local JVM. Every future injected method will be called remotely.
  *

--- a/xap-core/xap-datagrid/src/main/java/com/j_spaces/core/cache/fifoGroup/FifoGroupCacheImpl.java
+++ b/xap-core/xap-datagrid/src/main/java/com/j_spaces/core/cache/fifoGroup/FifoGroupCacheImpl.java
@@ -52,7 +52,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * TODO	add Javadoc
@@ -504,8 +503,8 @@ public class FifoGroupCacheImpl {
         return _numOfTemplates.get();
     }
 
-    public Object aquireIndexLock(Object obj) {
-        return _fgCacheHandeler.aquireIndexLock(obj);
+    public Object acquireIndexLock(Object obj) {
+        return _fgCacheHandeler.acquireIndexLock(obj);
     }
 
     public void releaseIndexLock(Object lockObject) {

--- a/xap-core/xap-datagrid/src/main/java/com/j_spaces/core/cache/fifoGroup/FifoGroupsCacheHandler.java
+++ b/xap-core/xap-datagrid/src/main/java/com/j_spaces/core/cache/fifoGroup/FifoGroupsCacheHandler.java
@@ -170,14 +170,14 @@ public class FifoGroupsCacheHandler {
             }
         }
 
-        public FgCacheElement aquireLock(Object obj) {
+        public FgCacheElement acquireLock(Object obj) {
             return _locks[obj.hashCode() & CACHE_POS_COMPUTE];
         }
 
         public void releaseLock(FgCacheElement lockObject) {
         }
 
-        public Object aquireIndexLock(Object obj) {
+        public Object acquireIndexLock(Object obj) {
             return _indexLocks[obj.hashCode() & CACHE_POS_COMPUTE];
         }
 
@@ -205,7 +205,7 @@ public class FifoGroupsCacheHandler {
         final ITemplateHolder lastRawmatchTemplate = context.getLastRawmatchTemplate();
 
 
-        FgCacheElement lock = _lm.aquireLock(val);
+        FgCacheElement lock = _lm.acquireLock(val);
 
         try {
             synchronized (lock) {
@@ -267,7 +267,7 @@ public class FifoGroupsCacheHandler {
 
 
     void removeEntryFromFGCache(Context context, String uid, Object val, XtnEntry xtnEntry) {
-        FgCacheElement lock = _lm.aquireLock(val);
+        FgCacheElement lock = _lm.acquireLock(val);
         try {
             synchronized (lock) {
                 lock.removeFromFGEntriesPerValue(val, uid, xtnEntry);
@@ -279,8 +279,8 @@ public class FifoGroupsCacheHandler {
 
     }
 
-    public Object aquireIndexLock(Object obj) {
-        return _lm.aquireIndexLock(obj);
+    public Object acquireIndexLock(Object obj) {
+        return _lm.acquireIndexLock(obj);
     }
 
     public void releaseIndexLock(Object lockObject) {

--- a/xap-core/xap-datagrid/src/main/java/com/j_spaces/core/cache/fifoGroup/FifoGroupsCompoundIndexExtention.java
+++ b/xap-core/xap-datagrid/src/main/java/com/j_spaces/core/cache/fifoGroup/FifoGroupsCompoundIndexExtention.java
@@ -57,7 +57,7 @@ public class FifoGroupsCompoundIndexExtention<K> implements IFifoGroupsIndexExte
             _index.insertEntryIndexedField_impl(pEntry, fieldValue, pType, pEntry.getBackRefs());
             return;
         }
-        Object lockObject = _fifoGroupsCacheImpl.aquireIndexLock(fieldValue);
+        Object lockObject = _fifoGroupsCacheImpl.acquireIndexLock(fieldValue);
         try {
             synchronized (lockObject) {
                 _index.insertEntryIndexedField_impl(pEntry, fieldValue, pType, pEntry.getBackRefs());
@@ -73,7 +73,7 @@ public class FifoGroupsCompoundIndexExtention<K> implements IFifoGroupsIndexExte
             _index.insertEntryIndexedField_impl(pEntry, fieldValue, pType, insertBackRefs);
             return;
         }
-        Object lockObject = _fifoGroupsCacheImpl.aquireIndexLock(fieldValue);
+        Object lockObject = _fifoGroupsCacheImpl.acquireIndexLock(fieldValue);
         try {
             synchronized (lockObject) {
                 _index.insertEntryIndexedField_impl(pEntry, fieldValue, pType, insertBackRefs);
@@ -132,7 +132,7 @@ public class FifoGroupsCompoundIndexExtention<K> implements IFifoGroupsIndexExte
                             fieldValue, refpos, removeIndexedValue, pEntry);
 
         }
-        Object lockObject = _fifoGroupsCacheImpl.aquireIndexLock(fieldValue);
+        Object lockObject = _fifoGroupsCacheImpl.acquireIndexLock(fieldValue);
         try {
             synchronized (lockObject) {
                 return

--- a/xap-core/xap-datagrid/src/main/java/com/j_spaces/core/cache/fifoGroup/FifoGroupsMainIndexExtention.java
+++ b/xap-core/xap-datagrid/src/main/java/com/j_spaces/core/cache/fifoGroup/FifoGroupsMainIndexExtention.java
@@ -55,7 +55,7 @@ public class FifoGroupsMainIndexExtention<K> implements IFifoGroupsIndexExtentio
             _index.insertEntryIndexedField_impl(pEntry, fieldValue, pType, pEntry.getBackRefs());
             return;
         }
-        Object lockObject = _fifoGroupsCacheImpl.aquireIndexLock(fieldValue);
+        Object lockObject = _fifoGroupsCacheImpl.acquireIndexLock(fieldValue);
         try {
             synchronized (lockObject) {
                 _index.insertEntryIndexedField_impl(pEntry, fieldValue, pType, pEntry.getBackRefs());
@@ -71,7 +71,7 @@ public class FifoGroupsMainIndexExtention<K> implements IFifoGroupsIndexExtentio
             _index.insertEntryIndexedField_impl(pEntry, fieldValue, pType, insertBackRefs);
             return;
         }
-        Object lockObject = _fifoGroupsCacheImpl.aquireIndexLock(fieldValue);
+        Object lockObject = _fifoGroupsCacheImpl.acquireIndexLock(fieldValue);
         try {
             synchronized (lockObject) {
                 _index.insertEntryIndexedField_impl(pEntry, fieldValue, pType, insertBackRefs);
@@ -102,7 +102,7 @@ public class FifoGroupsMainIndexExtention<K> implements IFifoGroupsIndexExtentio
                     _index.removeEntryIndexedField_impl(eh, deletedBackRefs,
                             fieldValue, refpos, removeIndexedValue, pEntry);
         }
-        Object lockObject = _fifoGroupsCacheImpl.aquireIndexLock(fieldValue);
+        Object lockObject = _fifoGroupsCacheImpl.acquireIndexLock(fieldValue);
         try {
             synchronized (lockObject) {
                 return

--- a/xap-core/xap-datagrid/src/main/java/com/j_spaces/kernel/ClassLoaderHelper.java
+++ b/xap-core/xap-datagrid/src/main/java/com/j_spaces/kernel/ClassLoaderHelper.java
@@ -58,7 +58,7 @@ public class ClassLoaderHelper {
 
     /**
      * @return direct private contextClassLoader field of Thread class or <code>null</code> if
-     * failed to aquire field.
+     * failed to acquire field.
      */
     final static private Field getContextThreadCLField() {
         Field threadCLField = null;

--- a/xap-extensions/xap-cassandra/src/main/java/org/openspaces/persistency/cassandra/CassandraSpaceDataSource.java
+++ b/xap-extensions/xap-cassandra/src/main/java/org/openspaces/persistency/cassandra/CassandraSpaceDataSource.java
@@ -244,7 +244,7 @@ public class CassandraSpaceDataSource extends ClusterInfoAwareSpaceDataSource {
     }
 
     private Object getByIdImpl(String typeName, Object id) {
-        return hectorClient.readDocmentByKey(mapper, typeName, id);
+        return hectorClient.readDocumentByKey(mapper, typeName, id);
     }
 
     @Override

--- a/xap-extensions/xap-cassandra/src/main/java/org/openspaces/persistency/cassandra/HectorCassandraClient.java
+++ b/xap-extensions/xap-cassandra/src/main/java/org/openspaces/persistency/cassandra/HectorCassandraClient.java
@@ -492,7 +492,7 @@ public class HectorCassandraClient {
     /**
      * Tries to read from the internal metadata column family, the {@link ColumnFamilyMetadata}
      * metadata matching the given type name. If found, this metadata is stored in cache and can
-     * later be aquired by calling {@link #getColumnFamilyMetadata(String)}
+     * later be acquired by calling {@link #getColumnFamilyMetadata(String)}
      *
      * @param typeName The typeName describing the matching column family.
      * @return The {@link ColumnFamilyMetadata} instance if found, null otherwise.
@@ -555,7 +555,7 @@ public class HectorCassandraClient {
      * @param keyValue The key of the requested entry.
      * @return The SpaceDocument matching the key if found, null otherwise.
      */
-    public SpaceDocument readDocmentByKey(
+    public SpaceDocument readDocumentByKey(
             SpaceDocumentColumnFamilyMapper mapper,
             String typeName,
             Object keyValue) {

--- a/xap-extensions/xap-cassandra/src/main/java/org/openspaces/persistency/cassandra/NamedLockProvider.java
+++ b/xap-extensions/xap-cassandra/src/main/java/org/openspaces/persistency/cassandra/NamedLockProvider.java
@@ -45,7 +45,7 @@ public class NamedLockProvider {
      * @param name The name of the lock to get
      * @return The shared {@link java.util.concurrent.locks.ReentrantLock} matching the provided
      * name. One is created if it doesn't already exist. Note that the returned {@link
-     * java.util.concurrent.locks.ReentrantLock} should still be aquired and released by the client
+     * java.util.concurrent.locks.ReentrantLock} should still be acquired and released by the client
      * calling this method.
      */
     public ReentrantLock forName(String name) {

--- a/xap-extensions/xap-cassandra/src/main/java/org/openspaces/persistency/cassandra/meta/mapping/SpaceDocumentColumnFamilyMapper.java
+++ b/xap-extensions/xap-cassandra/src/main/java/org/openspaces/persistency/cassandra/meta/mapping/SpaceDocumentColumnFamilyMapper.java
@@ -49,7 +49,7 @@ public interface SpaceDocumentColumnFamilyMapper {
      * @param metadata The metadata corresponding the the converted document's type name.
      * @param document The document typ convert.
      * @param rowType  The row type.
-     * @return A {@link ColumnFamilyRow} matching the provided docment.
+     * @return A {@link ColumnFamilyRow} matching the provided document.
      */
     ColumnFamilyRow toColumnFamilyRow(
             ColumnFamilyMetadata metadata,

--- a/xap-extensions/xap-cassandra/src/main/java/org/openspaces/persistency/cassandra/meta/mapping/node/PojoTypeNode.java
+++ b/xap-extensions/xap-cassandra/src/main/java/org/openspaces/persistency/cassandra/meta/mapping/node/PojoTypeNode.java
@@ -121,7 +121,7 @@ public class PojoTypeNode extends AbstractCompoundTypeNode
         }
 
         // this means we got here from readExternal so all the fixed properties 
-        // were already aquired from getChildren
+        // were already acquired from getChildren
         if (context == null) {
             return;
         }


### PR DESCRIPTION
### Renaming Suggestion of Method Names to Make Them More Descriptive
---
**Description**
---

We have developed a tool (**NameSpotter**) for identifying non-descriptive method names, and using this tool we find a non-descriptive method name in your repository:
```java
/* Non-descriptive Method Name in xap-core/xap-datagrid/src/main/java/com/j_spaces/core/cache/fifoGroup/FifoGroupsCacheHandler.java */
        public FgCacheElement aquireLock(Object obj) {
            return _locks[obj.hashCode() & CACHE_POS_COMPUTE];
        }

```
We considered "aquireLock" as non-descriptive because it contains a typo, i.e., "aquire" -> "acquire", which could be misleading.

```java
public SpaceDocument readDocmentByKey(
            SpaceDocumentColumnFamilyMapper mapper,
            String typeName,
            Object keyValue) {
        ColumnFamilyMetadata metadata = metadataCache.getColumnFamilyMetadata(typeName);
        if (metadata == null) {
            metadata = fetchColumnFamilyMetadata(typeName, mapper);

            if (metadata == null) {
                return null;
            }
        }

        ColumnFamilyTemplate<Object, String> template = getTemplate(metadata);

        if (!template.isColumnsExist(keyValue)) {
            return null;
        }

        SpaceDocumentMapper hectorMapper = getMapperTemplate(metadata, mapper);
        try {
            return template.queryColumns(keyValue, hectorMapper);
        } catch (Exception e) {
            // entry may have been removed in the meantime
            return null;
        }
    }
```
We considered "readDocmentByKey" as non-descriptive because it contains a typo, i.e., "Docment" -> "Document", which could be misleading. We have corrected them (including the comments and the same name occurring in other file) and submitted a pull request.

Do you agree with the judgment? 

- If not, could you please leave your valuable opinion?

- If you do agree, the relevant modification has been submitted as a PR, and thanks for your precious time to consider it.