### PR TITLE
PIC-2952 Allow round bracket for PlaceholderReplacer

### DIFF
--- a/xap-core/xap-openspaces/src/main/java/org/openspaces/core/util/PlaceholderReplacer.java
+++ b/xap-core/xap-openspaces/src/main/java/org/openspaces/core/util/PlaceholderReplacer.java
@@ -17,8 +17,9 @@
 package org.openspaces.core.util;
 
 import org.springframework.util.PropertyPlaceholderHelper;
-import org.springframework.util.PropertyPlaceholderHelper.PlaceholderResolver;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Map;
 
 /**
@@ -27,33 +28,40 @@ import java.util.Map;
 public class PlaceholderReplacer {
 
     /**
-     * Replaces each occurence of ${SOME_VALUE} with the varible SOME_VALUE in 'variables' If any
-     * error occures during parsing, i.e: variable doesn't exist, bad syntax, etc... a {@link
+     * Replaces each occurrence of ${SOME_VALUE} or $(SOME_VALUE) with the variable SOME_VALUE in 'variables' If any
+     * error occurs during parsing, i.e: variable doesn't exist, bad syntax, etc... a {@link
      * PlaceholderResolutionException} is thrown, otherwise the new string after all replacements
      * have been made will be returned.
      *
      * @param variables The variables map to match placeholders against
      * @param value     the string, possibly containing placeholders
      * @return the value after placeholder replacement have been made
-     * @throws PlaceholderResolutionException if an empty placeholder is found or a place holder
+     * @throws PlaceholderResolutionException if an empty placeholder is found or a placeholder
      *                                        with no suitable value in 'variables'
      */
     public static String replacePlaceholders(final Map<String, String> variables, final String value) throws PlaceholderResolutionException {
-        PropertyPlaceholderHelper helper = new PropertyPlaceholderHelper("${", "}");
-        return helper.replacePlaceholders(value, new PlaceholderResolver() {
-            public String resolvePlaceholder(String key) {
+        ArrayList<PropertyPlaceholderHelper> helpers = new ArrayList<>(
+                Arrays.asList(
+                        new PropertyPlaceholderHelper("${", "}"),
+                        new PropertyPlaceholderHelper("$(", ")")));
+
+        String result = value;
+        for (PropertyPlaceholderHelper helper : helpers) {
+            final String str = result;
+            result = helper.replacePlaceholders(str, key -> {
                 if (key.isEmpty()) {
-                    throw new PlaceholderResolutionException("Placeholder in '" + value + "' has to have a length of at least 1");
+                    throw new PlaceholderResolutionException("Placeholder in '" + str + "' has to have a length of at least 1");
                 }
 
-                String result = variables.get(key);
-                if (result == null) {
-                    throw new PlaceholderResolutionException("Missing value for placeholder: '" + key + "' in '" + value + "'");
+                String val = variables.get(key);
+                if (val == null) {
+                    throw new PlaceholderResolutionException("Missing value for placeholder: '" + key + "' in '" + str + "'");
                 }
 
-                return result;
-            }
-        });
+                return val;
+            });
+        }
+        return result;
     }
 
     // this class extends RuntimeException so it can be thrown from PlaceholderResolver#resolvePlaceholder as done above


### PR DESCRIPTION
Curly brackets are special characters in URL syntax according to [RFC 3986](https://www.rfc-editor.org/rfc/rfc3986#page-11).
Java compilation failure can occur if it is present in the Classpath section of the manifest file.
PlaceholderReplacer has to support other characters as placeholder in addition to curly brackets, e.g. round brackets in this pull request.